### PR TITLE
Copy FFmpeg's checkasm test utility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,7 @@ AC_CONFIG_FILES([Makefile
                  x86/Makefile
                  x86/config.asm
                  tests/Makefile
+                 tests/checkasm/Makefile
                  examples/Makefile
                  luajit/Makefile])
 AC_OUTPUT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,10 @@
 LOG_COMPILER = $(srcdir)/valgrind_wrapper.sh
 AM_LOG_FLAGS = $(srcdir)
 
+if HAVE_AVUTIL
+SUBDIRS = checkasm
+endif
+
 dist_check_SCRIPTS = \
 	uprobe_stdio_test.sh \
 	uprobe_syslog_test.sh \

--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -7,6 +7,7 @@ checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS) \
     $(top_builddir)/lib/upipe-v210/libupipe_v210.la
 
 checkasm_SOURCES = checkasm.c checkasm.h timer.h \
+    v210dec.c \
     v210enc.c
 
 if HAVE_X86ASM

--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -1,0 +1,20 @@
+check_PROGRAMS = checkasm
+
+TESTS = checkasm
+
+checkasm_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_builddir) -I$(top_builddir)/include $(AVUTIL_CFLAGS)
+checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS)
+
+checkasm_SOURCES = checkasm.c checkasm.h timer.h
+
+if HAVE_X86ASM
+checkasm_SOURCES += checkasm_x86.asm timer_x86.h
+endif
+
+V_ASM = $(V_ASM_@AM_V@)
+V_ASM_ = $(V_ASM_@AM_DEFAULT_VERBOSITY@)
+V_ASM_0 = @echo "  ASM     " $@;
+
+# NOTE: the extension is .o
+.asm.o:
+	$(V_ASM)$(LIBTOOL) $(AM_V_lt) --mode=compile --tag=CC $(NASM) $(NASMFLAGS) $< -o $@

--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -9,6 +9,7 @@ checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS) \
 
 checkasm_SOURCES = checkasm.c checkasm.h timer.h \
     sdidec.c \
+    sdienc.c \
     v210dec.c \
     v210enc.c
 

--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -4,9 +4,11 @@ TESTS = checkasm
 
 checkasm_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_builddir) -I$(top_builddir)/include $(AVUTIL_CFLAGS)
 checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS) \
+    $(top_builddir)/lib/upipe-hbrmt/libupipe_hbrmt.la \
     $(top_builddir)/lib/upipe-v210/libupipe_v210.la
 
 checkasm_SOURCES = checkasm.c checkasm.h timer.h \
+    sdidec.c \
     v210dec.c \
     v210enc.c
 

--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -3,9 +3,11 @@ check_PROGRAMS = checkasm
 TESTS = checkasm
 
 checkasm_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_builddir) -I$(top_builddir)/include $(AVUTIL_CFLAGS)
-checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS)
+checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS) \
+    $(top_builddir)/lib/upipe-v210/libupipe_v210.la
 
-checkasm_SOURCES = checkasm.c checkasm.h timer.h
+checkasm_SOURCES = checkasm.c checkasm.h timer.h \
+    v210enc.c
 
 if HAVE_X86ASM
 checkasm_SOURCES += checkasm_x86.asm timer_x86.h

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -75,6 +75,7 @@ static const struct {
     void (*func)(void);
 } tests[] = {
     { "sdidec", checkasm_check_sdidec },
+    { "sdienc", checkasm_check_sdienc },
     { "v210dec", checkasm_check_v210dec },
     { "v210enc", checkasm_check_v210enc },
     { NULL, NULL }

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -74,6 +74,7 @@ static const struct {
     const char *name;
     void (*func)(void);
 } tests[] = {
+    { "sdidec", checkasm_check_sdidec },
     { "v210dec", checkasm_check_v210dec },
     { "v210enc", checkasm_check_v210enc },
     { NULL, NULL }

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -74,6 +74,7 @@ static const struct {
     const char *name;
     void (*func)(void);
 } tests[] = {
+    { "v210enc", checkasm_check_v210enc },
     { NULL, NULL }
 };
 

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -74,6 +74,7 @@ static const struct {
     const char *name;
     void (*func)(void);
 } tests[] = {
+    { "v210dec", checkasm_check_v210dec },
     { "v210enc", checkasm_check_v210enc },
     { NULL, NULL }
 };

--- a/tests/checkasm/checkasm.c
+++ b/tests/checkasm/checkasm.c
@@ -1,0 +1,723 @@
+/*
+ * Assembly testing and benchmarking tool
+ * Copyright (c) 2015 Henrik Gramner
+ * Copyright (c) 2008 Loren Merritt
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* silence warnings caused by unknown config variables from FFmpeg */
+#define CONFIG_LINUX_PERF 0
+
+#if CONFIG_LINUX_PERF
+# ifndef _GNU_SOURCE
+#  define _GNU_SOURCE // for syscall (performance monitoring API)
+# endif
+#endif
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "checkasm.h"
+#include <libavutil/common.h>
+#include <libavutil/cpu.h>
+#include <libavutil/random_seed.h>
+
+#include "upipe/ubase.h"
+
+#if HAVE_IO_H
+#include <io.h>
+#endif
+
+#if HAVE_SETCONSOLETEXTATTRIBUTE
+#include <windows.h>
+#define COLOR_RED    FOREGROUND_RED
+#define COLOR_GREEN  FOREGROUND_GREEN
+#define COLOR_YELLOW (FOREGROUND_RED|FOREGROUND_GREEN)
+#else
+#define COLOR_RED    1
+#define COLOR_GREEN  2
+#define COLOR_YELLOW 3
+#endif
+
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#if !HAVE_ISATTY
+#define isatty(fd) 1
+#endif
+
+#if ARCH_ARM && HAVE_ARMV5TE_EXTERNAL
+#include "libavutil/arm/cpu.h"
+
+void (*checkasm_checked_call)(void *func, int dummy, ...) = checkasm_checked_call_novfp;
+#endif
+
+/* List of tests to invoke */
+static const struct {
+    const char *name;
+    void (*func)(void);
+} tests[] = {
+    { NULL, NULL }
+};
+
+/* List of cpu flags to check */
+static const struct {
+    const char *name;
+    const char *suffix;
+    int flag;
+} cpus[] = {
+#if   ARCH_AARCH64
+    { "ARMV8",    "armv8",    AV_CPU_FLAG_ARMV8 },
+    { "NEON",     "neon",     AV_CPU_FLAG_NEON },
+#elif ARCH_ARM
+    { "ARMV5TE",  "armv5te",  AV_CPU_FLAG_ARMV5TE },
+    { "ARMV6",    "armv6",    AV_CPU_FLAG_ARMV6 },
+    { "ARMV6T2",  "armv6t2",  AV_CPU_FLAG_ARMV6T2 },
+    { "VFP",      "vfp",      AV_CPU_FLAG_VFP },
+    { "VFP_VM",   "vfp_vm",   AV_CPU_FLAG_VFP_VM },
+    { "VFPV3",    "vfp3",     AV_CPU_FLAG_VFPV3 },
+    { "NEON",     "neon",     AV_CPU_FLAG_NEON },
+#elif ARCH_PPC
+    { "ALTIVEC",  "altivec",  AV_CPU_FLAG_ALTIVEC },
+    { "VSX",      "vsx",      AV_CPU_FLAG_VSX },
+    { "POWER8",   "power8",   AV_CPU_FLAG_POWER8 },
+#elif ARCH_X86
+    { "MMX",      "mmx",      AV_CPU_FLAG_MMX|AV_CPU_FLAG_CMOV },
+    { "MMXEXT",   "mmxext",   AV_CPU_FLAG_MMXEXT },
+    { "3DNOW",    "3dnow",    AV_CPU_FLAG_3DNOW },
+    { "3DNOWEXT", "3dnowext", AV_CPU_FLAG_3DNOWEXT },
+    { "SSE",      "sse",      AV_CPU_FLAG_SSE },
+    { "SSE2",     "sse2",     AV_CPU_FLAG_SSE2|AV_CPU_FLAG_SSE2SLOW },
+    { "SSE3",     "sse3",     AV_CPU_FLAG_SSE3|AV_CPU_FLAG_SSE3SLOW },
+    { "SSSE3",    "ssse3",    AV_CPU_FLAG_SSSE3|AV_CPU_FLAG_ATOM },
+    { "SSE4.1",   "sse4",     AV_CPU_FLAG_SSE4 },
+    { "SSE4.2",   "sse42",    AV_CPU_FLAG_SSE42 },
+#ifdef AV_CPU_FLAG_AESNI
+    { "AES-NI",   "aesni",    AV_CPU_FLAG_AESNI },
+#endif
+    { "AVX",      "avx",      AV_CPU_FLAG_AVX },
+    { "XOP",      "xop",      AV_CPU_FLAG_XOP },
+    { "FMA3",     "fma3",     AV_CPU_FLAG_FMA3 },
+    { "FMA4",     "fma4",     AV_CPU_FLAG_FMA4 },
+    { "AVX2",     "avx2",     AV_CPU_FLAG_AVX2 },
+#ifdef AV_CPU_FLAG_AVX512
+    { "AVX-512",  "avx512",   AV_CPU_FLAG_AVX512 },
+#endif
+#endif
+    { NULL, NULL, 0 }
+};
+
+typedef struct CheckasmFuncVersion {
+    struct CheckasmFuncVersion *next;
+    void *func;
+    int ok;
+    int cpu;
+    CheckasmPerf perf;
+} CheckasmFuncVersion;
+
+/* Binary search tree node */
+typedef struct CheckasmFunc {
+    struct CheckasmFunc *child[2];
+    CheckasmFuncVersion versions;
+    uint8_t color; /* 0 = red, 1 = black */
+    char name[1];
+} CheckasmFunc;
+
+/* Internal state */
+static struct {
+    CheckasmFunc *funcs;
+    CheckasmFunc *current_func;
+    CheckasmFuncVersion *current_func_ver;
+    const char *current_test_name;
+    const char *bench_pattern;
+    int bench_pattern_len;
+    int num_checked;
+    int num_failed;
+
+    /* perf */
+    int nop_time;
+    int sysfd;
+
+    int cpu_flag;
+    const char *cpu_flag_name;
+    const char *test_name;
+} state;
+
+/* PRNG state */
+AVLFG checkasm_lfg;
+
+/* float compare support code */
+static int is_negative(union av_intfloat32 u)
+{
+    return u.i >> 31;
+}
+
+int float_near_ulp(float a, float b, unsigned max_ulp)
+{
+    union av_intfloat32 x, y;
+
+    x.f = a;
+    y.f = b;
+
+    if (is_negative(x) != is_negative(y)) {
+        // handle -0.0 == +0.0
+        return a == b;
+    }
+
+    if (llabs((int64_t)x.i - y.i) <= max_ulp)
+        return 1;
+
+    return 0;
+}
+
+int float_near_ulp_array(const float *a, const float *b, unsigned max_ulp,
+                         unsigned len)
+{
+    unsigned i;
+
+    for (i = 0; i < len; i++) {
+        if (!float_near_ulp(a[i], b[i], max_ulp))
+            return 0;
+    }
+    return 1;
+}
+
+int float_near_abs_eps(float a, float b, float eps)
+{
+    float abs_diff = fabsf(a - b);
+
+    return abs_diff < eps;
+}
+
+int float_near_abs_eps_array(const float *a, const float *b, float eps,
+                         unsigned len)
+{
+    unsigned i;
+
+    for (i = 0; i < len; i++) {
+        if (!float_near_abs_eps(a[i], b[i], eps))
+            return 0;
+    }
+    return 1;
+}
+
+int float_near_abs_eps_ulp(float a, float b, float eps, unsigned max_ulp)
+{
+    return float_near_ulp(a, b, max_ulp) || float_near_abs_eps(a, b, eps);
+}
+
+int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
+                         unsigned max_ulp, unsigned len)
+{
+    unsigned i;
+
+    for (i = 0; i < len; i++) {
+        if (!float_near_abs_eps_ulp(a[i], b[i], eps, max_ulp))
+            return 0;
+    }
+    return 1;
+}
+
+int double_near_abs_eps(double a, double b, double eps)
+{
+    double abs_diff = fabs(a - b);
+
+    return abs_diff < eps;
+}
+
+int double_near_abs_eps_array(const double *a, const double *b, double eps,
+                              unsigned len)
+{
+    unsigned i;
+
+    for (i = 0; i < len; i++) {
+        if (!double_near_abs_eps(a[i], b[i], eps))
+            return 0;
+    }
+    return 1;
+}
+
+/* Print colored text to stderr if the terminal supports it */
+UBASE_FMT_PRINTF(2, 3)
+static void color_printf(int color, const char *fmt, ...)
+{
+    static int use_color = -1;
+    va_list arg;
+
+#if HAVE_SETCONSOLETEXTATTRIBUTE
+    static HANDLE con;
+    static WORD org_attributes;
+
+    if (use_color < 0) {
+        CONSOLE_SCREEN_BUFFER_INFO con_info;
+        con = GetStdHandle(STD_ERROR_HANDLE);
+        if (con && con != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(con, &con_info)) {
+            org_attributes = con_info.wAttributes;
+            use_color = 1;
+        } else
+            use_color = 0;
+    }
+    if (use_color)
+        SetConsoleTextAttribute(con, (org_attributes & 0xfff0) | (color & 0x0f));
+#else
+    if (use_color < 0) {
+        const char *term = getenv("TERM");
+        use_color = term && strcmp(term, "dumb") && isatty(2);
+    }
+    if (use_color)
+        fprintf(stderr, "\x1b[%d;3%dm", (color & 0x08) >> 3, color & 0x07);
+#endif
+
+    va_start(arg, fmt);
+    vfprintf(stderr, fmt, arg);
+    va_end(arg);
+
+    if (use_color) {
+#if HAVE_SETCONSOLETEXTATTRIBUTE
+        SetConsoleTextAttribute(con, org_attributes);
+#else
+        fprintf(stderr, "\x1b[0m");
+#endif
+    }
+}
+
+/* Deallocate a tree */
+static void destroy_func_tree(CheckasmFunc *f)
+{
+    if (f) {
+        CheckasmFuncVersion *v = f->versions.next;
+        while (v) {
+            CheckasmFuncVersion *next = v->next;
+            free(v);
+            v = next;
+        }
+
+        destroy_func_tree(f->child[0]);
+        destroy_func_tree(f->child[1]);
+        free(f);
+    }
+}
+
+/* Allocate a zero-initialized block, clean up and exit on failure */
+static void *checkasm_malloc(size_t size)
+{
+    void *ptr = calloc(1, size);
+    if (!ptr) {
+        fprintf(stderr, "checkasm: malloc failed\n");
+        destroy_func_tree(state.funcs);
+        exit(1);
+    }
+    return ptr;
+}
+
+/* Get the suffix of the specified cpu flag */
+static const char *cpu_suffix(int cpu)
+{
+    int i = FF_ARRAY_ELEMS(cpus);
+
+    while (--i >= 0)
+        if (cpu & cpus[i].flag)
+            return cpus[i].suffix;
+
+    return "c";
+}
+
+static int cmp_nop(const void *a, const void *b)
+{
+    return *(const uint16_t*)a - *(const uint16_t*)b;
+}
+
+/* Measure the overhead of the timing code (in decicycles) */
+static int measure_nop_time(void)
+{
+    uint16_t nops[10000];
+    int i, nop_sum = 0;
+    av_unused const int sysfd = state.sysfd;
+
+    uint64_t t = 0;
+    for (i = 0; i < 10000; i++) {
+        PERF_START(t);
+        PERF_STOP(t);
+        nops[i] = t;
+    }
+
+    qsort(nops, 10000, sizeof(uint16_t), cmp_nop);
+    for (i = 2500; i < 7500; i++)
+        nop_sum += nops[i];
+
+    return nop_sum / 500;
+}
+
+/* Print benchmark results */
+static void print_benchs(CheckasmFunc *f)
+{
+    if (f) {
+        print_benchs(f->child[0]);
+
+        /* Only print functions with at least one assembly version */
+        if (f->versions.cpu || f->versions.next) {
+            CheckasmFuncVersion *v = &f->versions;
+            do {
+                CheckasmPerf *p = &v->perf;
+                if (p->iterations) {
+                    int decicycles = (10*p->cycles/p->iterations - state.nop_time) / 4;
+                    printf("%s_%s: %d.%d\n", f->name, cpu_suffix(v->cpu), decicycles/10, decicycles%10);
+                }
+            } while ((v = v->next));
+        }
+
+        print_benchs(f->child[1]);
+    }
+}
+
+/* ASCIIbetical sort except preserving natural order for numbers */
+static int cmp_func_names(const char *a, const char *b)
+{
+    const char *start = a;
+    int ascii_diff, digit_diff;
+
+    for (; !(ascii_diff = *(const unsigned char*)a - *(const unsigned char*)b) && *a; a++, b++);
+    for (; av_isdigit(*a) && av_isdigit(*b); a++, b++);
+
+    if (a > start && av_isdigit(a[-1]) && (digit_diff = av_isdigit(*a) - av_isdigit(*b)))
+        return digit_diff;
+
+    return ascii_diff;
+}
+
+/* Perform a tree rotation in the specified direction and return the new root */
+static CheckasmFunc *rotate_tree(CheckasmFunc *f, int dir)
+{
+    CheckasmFunc *r = f->child[dir^1];
+    f->child[dir^1] = r->child[dir];
+    r->child[dir] = f;
+    r->color = f->color;
+    f->color = 0;
+    return r;
+}
+
+#define is_red(f) ((f) && !(f)->color)
+
+/* Balance a left-leaning red-black tree at the specified node */
+static void balance_tree(CheckasmFunc **root)
+{
+    CheckasmFunc *f = *root;
+
+    if (is_red(f->child[0]) && is_red(f->child[1])) {
+        f->color ^= 1;
+        f->child[0]->color = f->child[1]->color = 1;
+    }
+
+    if (!is_red(f->child[0]) && is_red(f->child[1]))
+        *root = rotate_tree(f, 0); /* Rotate left */
+    else if (is_red(f->child[0]) && is_red(f->child[0]->child[0]))
+        *root = rotate_tree(f, 1); /* Rotate right */
+}
+
+/* Get a node with the specified name, creating it if it doesn't exist */
+static CheckasmFunc *get_func(CheckasmFunc **root, const char *name)
+{
+    CheckasmFunc *f = *root;
+
+    if (f) {
+        /* Search the tree for a matching node */
+        int cmp = cmp_func_names(name, f->name);
+        if (cmp) {
+            f = get_func(&f->child[cmp > 0], name);
+
+            /* Rebalance the tree on the way up if a new node was inserted */
+            if (!f->versions.func)
+                balance_tree(root);
+        }
+    } else {
+        /* Allocate and insert a new node into the tree */
+        int name_length = strlen(name);
+        f = *root = checkasm_malloc(sizeof(CheckasmFunc) + name_length);
+        memcpy(f->name, name, name_length + 1);
+    }
+
+    return f;
+}
+
+/* Perform tests and benchmarks for the specified cpu flag if supported by the host */
+static void check_cpu_flag(const char *name, int flag)
+{
+    int old_cpu_flag = state.cpu_flag;
+
+    flag |= old_cpu_flag;
+    av_force_cpu_flags(-1);
+    state.cpu_flag = flag & av_get_cpu_flags();
+    av_force_cpu_flags(state.cpu_flag);
+
+    if (!flag || state.cpu_flag != old_cpu_flag) {
+        int i;
+
+        state.cpu_flag_name = name;
+        for (i = 0; tests[i].func; i++) {
+            if (state.test_name && strcmp(tests[i].name, state.test_name))
+                continue;
+            state.current_test_name = tests[i].name;
+            tests[i].func();
+        }
+    }
+}
+
+/* Print the name of the current CPU flag, but only do it once */
+static void print_cpu_name(void)
+{
+    if (state.cpu_flag_name) {
+        color_printf(COLOR_YELLOW, "%s:\n", state.cpu_flag_name);
+        state.cpu_flag_name = NULL;
+    }
+}
+
+#if CONFIG_LINUX_PERF
+static int bench_init_linux(void)
+{
+    struct perf_event_attr attr = {
+        .type           = PERF_TYPE_HARDWARE,
+        .size           = sizeof(struct perf_event_attr),
+        .config         = PERF_COUNT_HW_CPU_CYCLES,
+        .disabled       = 1, // start counting only on demand
+        .exclude_kernel = 1,
+        .exclude_hv     = 1,
+    };
+
+    printf("benchmarking with Linux Perf Monitoring API\n");
+
+    state.sysfd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
+    if (state.sysfd == -1) {
+        perror("syscall");
+        return -1;
+    }
+    return 0;
+}
+#endif
+
+static int bench_init_ffmpeg(void)
+{
+#ifdef AV_READ_TIME
+    printf("benchmarking with native FFmpeg timers\n");
+    return 0;
+#else
+    fprintf(stderr, "checkasm: --bench is not supported on your system\n");
+    return -1;
+#endif
+}
+
+static int bench_init(void)
+{
+#if CONFIG_LINUX_PERF
+    int ret = bench_init_linux();
+#else
+    int ret = bench_init_ffmpeg();
+#endif
+    if (ret < 0)
+        return ret;
+
+    state.nop_time = measure_nop_time();
+    printf("nop: %d.%d\n", state.nop_time/10, state.nop_time%10);
+    return 0;
+}
+
+static void bench_uninit(void)
+{
+#if CONFIG_LINUX_PERF
+    if (state.sysfd > 0)
+        close(state.sysfd);
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+    unsigned int seed = av_get_random_seed();
+    int i, ret = 0;
+
+#if ARCH_ARM && HAVE_ARMV5TE_EXTERNAL
+    if (have_vfp(av_get_cpu_flags()) || have_neon(av_get_cpu_flags()))
+        checkasm_checked_call = checkasm_checked_call_vfp;
+#endif
+
+    if (!tests[0].func || !cpus[0].flag) {
+        fprintf(stderr, "checkasm: no tests to perform\n");
+        return 0;
+    }
+
+    while (argc > 1) {
+        if (!strncmp(argv[1], "--bench", 7)) {
+            if (bench_init() < 0)
+                return 1;
+            if (argv[1][7] == '=') {
+                state.bench_pattern = argv[1] + 8;
+                state.bench_pattern_len = strlen(state.bench_pattern);
+            } else
+                state.bench_pattern = "";
+        } else if (!strncmp(argv[1], "--test=", 7)) {
+            state.test_name = argv[1] + 7;
+        } else {
+            seed = strtoul(argv[1], NULL, 10);
+        }
+
+        argc--;
+        argv++;
+    }
+
+    fprintf(stderr, "checkasm: using random seed %u\n", seed);
+    av_lfg_init(&checkasm_lfg, seed);
+
+    check_cpu_flag(NULL, 0);
+    for (i = 0; cpus[i].flag; i++)
+        check_cpu_flag(cpus[i].name, cpus[i].flag);
+
+    if (state.num_failed) {
+        fprintf(stderr, "checkasm: %d of %d tests have failed\n", state.num_failed, state.num_checked);
+        ret = 1;
+    } else {
+        fprintf(stderr, "checkasm: all %d tests passed\n", state.num_checked);
+        if (state.bench_pattern) {
+            print_benchs(state.funcs);
+        }
+    }
+
+    destroy_func_tree(state.funcs);
+    bench_uninit();
+    return ret;
+}
+
+/* Decide whether or not the specified function needs to be tested and
+ * allocate/initialize data structures if needed. Returns a pointer to a
+ * reference function if the function should be tested, otherwise NULL */
+void *checkasm_check_func(void *func, const char *name, ...)
+{
+    char name_buf[256];
+    void *ref = func;
+    CheckasmFuncVersion *v;
+    int name_length;
+    va_list arg;
+
+    va_start(arg, name);
+    name_length = vsnprintf(name_buf, sizeof(name_buf), name, arg);
+    va_end(arg);
+
+    if (!func || name_length <= 0 || name_length >= sizeof(name_buf))
+        return NULL;
+
+    state.current_func = get_func(&state.funcs, name_buf);
+    state.funcs->color = 1;
+    v = &state.current_func->versions;
+
+    if (v->func) {
+        CheckasmFuncVersion *prev;
+        do {
+            /* Only test functions that haven't already been tested */
+            if (v->func == func)
+                return NULL;
+
+            if (v->ok)
+                ref = v->func;
+
+            prev = v;
+        } while ((v = v->next));
+
+        v = prev->next = checkasm_malloc(sizeof(CheckasmFuncVersion));
+    }
+
+    v->func = func;
+    v->ok = 1;
+    v->cpu = state.cpu_flag;
+    state.current_func_ver = v;
+
+    if (state.cpu_flag)
+        state.num_checked++;
+
+    return ref;
+}
+
+/* Decide whether or not the current function needs to be benchmarked */
+int checkasm_bench_func(void)
+{
+    return !state.num_failed && state.bench_pattern &&
+           !strncmp(state.current_func->name, state.bench_pattern, state.bench_pattern_len);
+}
+
+/* Indicate that the current test has failed */
+void checkasm_fail_func(const char *msg, ...)
+{
+    if (state.current_func_ver->cpu && state.current_func_ver->ok) {
+        va_list arg;
+
+        print_cpu_name();
+        fprintf(stderr, "   %s_%s (", state.current_func->name, cpu_suffix(state.current_func_ver->cpu));
+        va_start(arg, msg);
+        vfprintf(stderr, msg, arg);
+        va_end(arg);
+        fprintf(stderr, ")\n");
+
+        state.current_func_ver->ok = 0;
+        state.num_failed++;
+    }
+}
+
+/* Get the benchmark context of the current function */
+CheckasmPerf *checkasm_get_perf_context(void)
+{
+    CheckasmPerf *perf = &state.current_func_ver->perf;
+    memset(perf, 0, sizeof(*perf));
+    perf->sysfd = state.sysfd;
+    return perf;
+}
+
+/* Print the outcome of all tests performed since the last time this function was called */
+void checkasm_report(const char *name, ...)
+{
+    static int prev_checked, prev_failed, max_length;
+
+    if (state.num_checked > prev_checked) {
+        int pad_length = max_length + 4;
+        va_list arg;
+
+        print_cpu_name();
+        pad_length -= fprintf(stderr, " - %s.", state.current_test_name);
+        va_start(arg, name);
+        pad_length -= vfprintf(stderr, name, arg);
+        va_end(arg);
+        fprintf(stderr, "%*c", FFMAX(pad_length, 0) + 2, '[');
+
+        if (state.num_failed == prev_failed)
+            color_printf(COLOR_GREEN, "OK");
+        else
+            color_printf(COLOR_RED, "FAILED");
+        fprintf(stderr, "]\n");
+
+        prev_checked = state.num_checked;
+        prev_failed  = state.num_failed;
+    } else if (!state.cpu_flag) {
+        /* Calculate the amount of padding required to make the output vertically aligned */
+        int length = strlen(state.current_test_name);
+        va_list arg;
+
+        va_start(arg, name);
+        length += vsnprintf(NULL, 0, name, arg);
+        va_end(arg);
+
+        if (length > max_length)
+            max_length = length;
+    }
+}

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -68,6 +68,7 @@
 #include "timer.h"
 
 void checkasm_check_sdidec(void);
+void checkasm_check_sdienc(void);
 void checkasm_check_v210dec(void);
 void checkasm_check_v210enc(void);
 

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -67,6 +67,7 @@
 #define HAVE_RDTSC 0
 #include "timer.h"
 
+void checkasm_check_v210dec(void);
 void checkasm_check_v210enc(void);
 
 struct CheckasmPerf;

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -67,6 +67,8 @@
 #define HAVE_RDTSC 0
 #include "timer.h"
 
+void checkasm_check_v210enc(void);
+
 struct CheckasmPerf;
 
 void *checkasm_check_func(void *func, const char *name, ...) av_printf_format(2, 3);

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -67,6 +67,7 @@
 #define HAVE_RDTSC 0
 #include "timer.h"
 
+void checkasm_check_sdidec(void);
 void checkasm_check_v210dec(void);
 void checkasm_check_v210enc(void);
 

--- a/tests/checkasm/checkasm.h
+++ b/tests/checkasm/checkasm.h
@@ -1,0 +1,246 @@
+/*
+ * Assembly testing and benchmarking tool
+ * Copyright (c) 2015 Henrik Gramner
+ * Copyright (c) 2008 Loren Merritt
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef TESTS_CHECKASM_CHECKASM_H
+#define TESTS_CHECKASM_CHECKASM_H
+
+#include <stdint.h>
+#include "config.h"
+
+/* silence warnings caused by unknown config variables from FFmpeg */
+#define ARCH_AARCH64 0
+#define ARCH_ARM 0
+#define ARCH_PPC 0
+#define CONFIG_LINUX_PERF 0
+#define HAVE_IO_H 0
+#define HAVE_ISATTY 0
+#define HAVE_SETCONSOLETEXTATTRIBUTE 0
+
+#if defined(__i686__) || defined(__x86_64__)
+    #define ARCH_X86 1
+    #if defined(__i686__)
+        #define ARCH_X86_32 1
+        #define ARCH_X86_64 0
+    #elif defined(__x86_64__)
+        #define ARCH_X86_32 0
+        #define ARCH_X86_64 1
+    #endif
+#else
+    #define ARCH_X86 0
+    #define ARCH_X86_32 0
+    #define ARCH_X86_64 0
+#endif
+
+#if CONFIG_LINUX_PERF
+#include <unistd.h> // read(3)
+#include <sys/ioctl.h>
+#include <asm/unistd.h>
+#include <linux/perf_event.h>
+#endif
+
+#include <libavutil/avstring.h>
+#include <libavutil/cpu.h>
+#include <libavutil/lfg.h>
+
+/* silence warnings caused by unknown config variables from FFmpeg */
+#define HAVE_INLINE_ASM 1
+#define HAVE_MACH_ABSOLUTE_TIME 0
+#define HAVE_RDTSC 0
+#include "timer.h"
+
+struct CheckasmPerf;
+
+void *checkasm_check_func(void *func, const char *name, ...) av_printf_format(2, 3);
+int checkasm_bench_func(void);
+void checkasm_fail_func(const char *msg, ...) av_printf_format(1, 2);
+struct CheckasmPerf *checkasm_get_perf_context(void);
+void checkasm_report(const char *name, ...) av_printf_format(1, 2);
+
+/* float compare utilities */
+int float_near_ulp(float a, float b, unsigned max_ulp);
+int float_near_abs_eps(float a, float b, float eps);
+int float_near_abs_eps_ulp(float a, float b, float eps, unsigned max_ulp);
+int float_near_ulp_array(const float *a, const float *b, unsigned max_ulp,
+                         unsigned len);
+int float_near_abs_eps_array(const float *a, const float *b, float eps,
+                             unsigned len);
+int float_near_abs_eps_array_ulp(const float *a, const float *b, float eps,
+                                 unsigned max_ulp, unsigned len);
+int double_near_abs_eps(double a, double b, double eps);
+int double_near_abs_eps_array(const double *a, const double *b, double eps,
+                              unsigned len);
+
+extern AVLFG checkasm_lfg;
+#define rnd() av_lfg_get(&checkasm_lfg)
+
+static av_unused void *func_ref, *func_new;
+
+#define BENCH_RUNS 1000 /* Trade-off between accuracy and speed */
+
+/* Decide whether or not the specified function needs to be tested */
+#define check_func(func, ...) (func_ref = checkasm_check_func((func_new = func), __VA_ARGS__))
+
+/* Declare the function prototype. The first argument is the return value, the remaining
+ * arguments are the function parameters. Naming parameters is optional. */
+#define declare_func(ret, ...) declare_new(ret, __VA_ARGS__) typedef ret func_type(__VA_ARGS__)
+#define declare_func_float(ret, ...) declare_new_float(ret, __VA_ARGS__) typedef ret func_type(__VA_ARGS__)
+#define declare_func_emms(cpu_flags, ret, ...) declare_new_emms(cpu_flags, ret, __VA_ARGS__) typedef ret func_type(__VA_ARGS__)
+
+/* Indicate that the current test has failed */
+#define fail() checkasm_fail_func("%s:%d", av_basename(__FILE__), __LINE__)
+
+/* Print the test outcome */
+#define report checkasm_report
+
+/* Call the reference function */
+#define call_ref(...) ((func_type *)func_ref)(__VA_ARGS__)
+
+#if ARCH_X86 && HAVE_X86ASM
+/* Verifies that clobbered callee-saved registers are properly saved and restored
+ * and that either no MMX registers are touched or emms is issued */
+void checkasm_checked_call(void *func, ...);
+/* Verifies that clobbered callee-saved registers are properly saved and restored
+ * and issues emms for asm functions which are not required to do so */
+void checkasm_checked_call_emms(void *func, ...);
+/* Verifies that clobbered callee-saved registers are properly saved and restored
+ * but doesn't issue emms. Meant for dsp functions returning float or double */
+void checkasm_checked_call_float(void *func, ...);
+
+#if ARCH_X86_64
+/* Evil hack: detect incorrect assumptions that 32-bit ints are zero-extended to 64-bit.
+ * This is done by clobbering the stack with junk around the stack pointer and calling the
+ * assembly function through checked_call() with added dummy arguments which forces all
+ * real arguments to be passed on the stack and not in registers. For 32-bit arguments the
+ * upper half of the 64-bit register locations on the stack will now contain junk which will
+ * cause misbehaving functions to either produce incorrect output or segfault. Note that
+ * even though this works extremely well in practice, it's technically not guaranteed
+ * and false negatives is theoretically possible, but there can never be any false positives.
+ */
+void checkasm_stack_clobber(uint64_t clobber, ...);
+#define declare_new(ret, ...) ret (*checked_call)(void *, int, int, int, int, int, __VA_ARGS__)\
+                              = (void *)checkasm_checked_call;
+#define declare_new_float(ret, ...) ret (*checked_call)(void *, int, int, int, int, int, __VA_ARGS__)\
+                                    = (void *)checkasm_checked_call_float;
+#define declare_new_emms(cpu_flags, ret, ...) \
+    ret (*checked_call)(void *, int, int, int, int, int, __VA_ARGS__) = \
+        ((cpu_flags) & av_get_cpu_flags()) ? (void *)checkasm_checked_call_emms : \
+                                             (void *)checkasm_checked_call;
+#define CLOB (UINT64_C(0xdeadbeefdeadbeef))
+#define call_new(...) (checkasm_stack_clobber(CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,\
+                                              CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB),\
+                      checked_call(func_new, 0, 0, 0, 0, 0, __VA_ARGS__))
+#elif ARCH_X86_32
+#define declare_new(ret, ...) ret (*checked_call)(void *, __VA_ARGS__) = (void *)checkasm_checked_call;
+#define declare_new_float(ret, ...) ret (*checked_call)(void *, __VA_ARGS__) = (void *)checkasm_checked_call_float;
+#define declare_new_emms(cpu_flags, ret, ...) ret (*checked_call)(void *, __VA_ARGS__) = \
+        ((cpu_flags) & av_get_cpu_flags()) ? (void *)checkasm_checked_call_emms :        \
+                                             (void *)checkasm_checked_call;
+#define call_new(...) checked_call(func_new, __VA_ARGS__)
+#endif
+#elif ARCH_ARM && HAVE_ARMV5TE_EXTERNAL
+/* Use a dummy argument, to offset the real parameters by 2, not only 1.
+ * This makes sure that potential 8-byte-alignment of parameters is kept the same
+ * even when the extra parameters have been removed. */
+void checkasm_checked_call_vfp(void *func, int dummy, ...);
+void checkasm_checked_call_novfp(void *func, int dummy, ...);
+extern void (*checkasm_checked_call)(void *func, int dummy, ...);
+#define declare_new(ret, ...) ret (*checked_call)(void *, int dummy, __VA_ARGS__) = (void *)checkasm_checked_call;
+#define call_new(...) checked_call(func_new, 0, __VA_ARGS__)
+#elif ARCH_AARCH64 && !defined(__APPLE__)
+void checkasm_stack_clobber(uint64_t clobber, ...);
+void checkasm_checked_call(void *func, ...);
+#define declare_new(ret, ...) ret (*checked_call)(void *, int, int, int, int, int, int, int, __VA_ARGS__)\
+                              = (void *)checkasm_checked_call;
+#define CLOB (UINT64_C(0xdeadbeefdeadbeef))
+#define call_new(...) (checkasm_stack_clobber(CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,\
+                                              CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB,CLOB),\
+                      checked_call(func_new, 0, 0, 0, 0, 0, 0, 0, __VA_ARGS__))
+#else
+#define declare_new(ret, ...)
+#define declare_new_float(ret, ...)
+#define declare_new_emms(cpu_flags, ret, ...)
+/* Call the function */
+#define call_new(...) ((func_type *)func_new)(__VA_ARGS__)
+#endif
+
+#ifndef declare_new_emms
+#define declare_new_emms(cpu_flags, ret, ...) declare_new(ret, __VA_ARGS__)
+#endif
+#ifndef declare_new_float
+#define declare_new_float(ret, ...) declare_new(ret, __VA_ARGS__)
+#endif
+
+typedef struct CheckasmPerf {
+    int sysfd;
+    uint64_t cycles;
+    int iterations;
+} CheckasmPerf;
+
+#if defined(AV_READ_TIME) || CONFIG_LINUX_PERF
+
+#if CONFIG_LINUX_PERF
+#define PERF_START(t) do {                              \
+    ioctl(sysfd, PERF_EVENT_IOC_RESET, 0);              \
+    ioctl(sysfd, PERF_EVENT_IOC_ENABLE, 0);             \
+} while (0)
+#define PERF_STOP(t) do {                               \
+    ioctl(sysfd, PERF_EVENT_IOC_DISABLE, 0);            \
+    read(sysfd, &t, sizeof(t));                         \
+} while (0)
+#else
+#define PERF_START(t) t = AV_READ_TIME()
+#define PERF_STOP(t)  t = AV_READ_TIME() - t
+#endif
+
+/* Benchmark the function */
+#define bench_new(...)\
+    do {\
+        if (checkasm_bench_func()) {\
+            struct CheckasmPerf *perf = checkasm_get_perf_context();\
+            av_unused const int sysfd = perf->sysfd;\
+            func_type *tfunc = func_new;\
+            uint64_t tsum = 0;\
+            int ti, tcount = 0;\
+            uint64_t t = 0; \
+            for (ti = 0; ti < BENCH_RUNS; ti++) {\
+                PERF_START(t);\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                tfunc(__VA_ARGS__);\
+                PERF_STOP(t);\
+                if (t*tcount <= tsum*4 && ti > 0) {\
+                    tsum += t;\
+                    tcount++;\
+                }\
+            }\
+            perf->cycles += t;\
+            perf->iterations++;\
+        }\
+    } while (0)
+#else
+#define bench_new(...) while(0)
+#define PERF_START(t)  while(0)
+#define PERF_STOP(t)   while(0)
+#endif
+
+#endif /* TESTS_CHECKASM_CHECKASM_H */

--- a/tests/checkasm/checkasm_x86.asm
+++ b/tests/checkasm/checkasm_x86.asm
@@ -1,0 +1,244 @@
+;*****************************************************************************
+;* Assembly testing and benchmarking tool
+;* Copyright (c) 2008 Loren Merritt
+;* Copyright (c) 2012 Henrik Gramner
+;*
+;* This file is part of FFmpeg.
+;*
+;* FFmpeg is free software; you can redistribute it and/or modify
+;* it under the terms of the GNU General Public License as published by
+;* the Free Software Foundation; either version 2 of the License, or
+;* (at your option) any later version.
+;*
+;* FFmpeg is distributed in the hope that it will be useful,
+;* but WITHOUT ANY WARRANTY; without even the implied warranty of
+;* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;* GNU General Public License for more details.
+;*
+;* You should have received a copy of the GNU General Public License
+;* along with this program; if not, write to the Free Software
+;* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02111, USA.
+;*****************************************************************************
+
+%define private_prefix checkasm
+%include "x86inc.asm"
+
+SECTION_RODATA
+
+error_message: db "failed to preserve register", 0
+error_message_emms: db "failed to issue emms", 0
+
+%if ARCH_X86_64
+; just random numbers to reduce the chance of incidental match
+ALIGN 16
+x6:  dq 0x1a1b2550a612b48c,0x79445c159ce79064
+x7:  dq 0x2eed899d5a28ddcd,0x86b2536fcd8cf636
+x8:  dq 0xb0856806085e7943,0x3f2bf84fc0fcca4e
+x9:  dq 0xacbd382dcf5b8de2,0xd229e1f5b281303f
+x10: dq 0x71aeaff20b095fd9,0xab63e2e11fa38ed9
+x11: dq 0x89b0c0765892729a,0x77d410d5c42c882d
+x12: dq 0xc45ea11a955d8dd5,0x24b3c1d2a024048b
+x13: dq 0x2e8ec680de14b47c,0xdd7b8919edd42786
+x14: dq 0x135ce6888fa02cbf,0x11e53e2b2ac655ef
+x15: dq 0x011ff554472a7a10,0x6de8f4c914c334d5
+n7:  dq 0x21f86d66c8ca00ce
+n8:  dq 0x75b6ba21077c48ad
+n9:  dq 0xed56bb2dcb3c7736
+n10: dq 0x8bda43d3fd1a7e06
+n11: dq 0xb64a9c9e5d318408
+n12: dq 0xdf9a54b303f1d3a3
+n13: dq 0x4a75479abd64e097
+n14: dq 0x249214109d5d1c88
+%endif
+
+SECTION .text
+
+cextern fail_func
+
+; max number of args used by any asm function.
+; (max_args % 4) must equal 3 for stack alignment
+%define max_args 15
+
+%if ARCH_X86_64
+
+;-----------------------------------------------------------------------------
+; int checkasm_stack_clobber(uint64_t clobber, ...)
+;-----------------------------------------------------------------------------
+cglobal stack_clobber, 1,2
+    ; Clobber the stack with junk below the stack pointer
+    %define argsize (max_args+6)*8
+    SUB  rsp, argsize
+    mov   r1, argsize-8
+.loop:
+    mov [rsp+r1], r0
+    sub   r1, 8
+    jge .loop
+    ADD  rsp, argsize
+    RET
+
+%if WIN64
+    %assign free_regs 7
+    DECLARE_REG_TMP 4
+%else
+    %assign free_regs 9
+    DECLARE_REG_TMP 7
+%endif
+
+%macro report_fail 1
+    mov  r9, rax
+    mov r10, rdx
+    lea  r0, [%1]
+    xor eax, eax
+    call fail_func
+    mov rdx, r10
+    mov rax, r9
+%endmacro
+
+;-----------------------------------------------------------------------------
+; void checkasm_checked_call(void *func, ...)
+;-----------------------------------------------------------------------------
+INIT_XMM
+%macro CHECKED_CALL 0-1
+cglobal checked_call%1, 2,15,16,max_args*8+8
+    mov  t0, r0
+
+    ; All arguments have been pushed on the stack instead of registers in order to
+    ; test for incorrect assumptions that 32-bit ints are zero-extended to 64-bit.
+    mov  r0, r6mp
+    mov  r1, r7mp
+    mov  r2, r8mp
+    mov  r3, r9mp
+%if UNIX64
+    mov  r4, r10mp
+    mov  r5, r11mp
+    %assign i 6
+    %rep max_args-6
+        mov  r9, [rsp+stack_offset+(i+1)*8]
+        mov  [rsp+(i-6)*8], r9
+        %assign i i+1
+    %endrep
+%else ; WIN64
+    %assign i 4
+    %rep max_args-4
+        mov  r9, [rsp+stack_offset+(i+7)*8]
+        mov  [rsp+i*8], r9
+        %assign i i+1
+    %endrep
+
+    ; Move possible floating-point arguments to the correct registers
+    movq m0, r0
+    movq m1, r1
+    movq m2, r2
+    movq m3, r3
+
+    %assign i 6
+    %rep 16-6
+        mova m %+ i, [x %+ i]
+        %assign i i+1
+    %endrep
+%endif
+
+%assign i 14
+%rep 15-free_regs
+    mov r %+ i, [n %+ i]
+    %assign i i-1
+%endrep
+    call t0
+%assign i 14
+%rep 15-free_regs
+    xor r %+ i, [n %+ i]
+    or  r14, r %+ i
+    %assign i i-1
+%endrep
+
+%if WIN64
+    %assign i 6
+    %rep 16-6
+        pxor m %+ i, [x %+ i]
+        por  m6, m %+ i
+        %assign i i+1
+    %endrep
+    packsswb m6, m6
+    movq r5, m6
+    or  r14, r5
+%endif
+
+    ; Call fail_func() with a descriptive message to mark it as a failure
+    ; if the called function didn't preserve all callee-saved registers.
+    ; Save the return value located in rdx:rax first to prevent clobbering.
+    jz .clobber_ok
+    report_fail error_message
+.clobber_ok:
+%ifidn %1, _emms
+    emms
+%elifnidn %1, _float
+    fstenv [rsp]
+    cmp  word [rsp + 8], 0xffff
+    je   .emms_ok
+    report_fail error_message_emms
+    emms
+.emms_ok:
+%endif
+    RET
+%endmacro
+
+%else
+
+; just random numbers to reduce the chance of incidental match
+%define n3 dword 0x6549315c
+%define n4 dword 0xe02f3e23
+%define n5 dword 0xb78d0d1d
+%define n6 dword 0x33627ba7
+
+%macro report_fail 1
+    mov  r3, eax
+    mov  r4, edx
+    lea  r0, [%1]
+    mov [esp], r0
+    call fail_func
+    mov  edx, r4
+    mov  eax, r3
+%endmacro
+
+%macro CHECKED_CALL 0-1
+;-----------------------------------------------------------------------------
+; void checkasm_checked_call(void *func, ...)
+;-----------------------------------------------------------------------------
+cglobal checked_call%1, 1,7
+    mov  r3, n3
+    mov  r4, n4
+    mov  r5, n5
+    mov  r6, n6
+%rep max_args
+    PUSH dword [esp+20+max_args*4]
+%endrep
+    call r0
+    xor  r3, n3
+    xor  r4, n4
+    xor  r5, n5
+    xor  r6, n6
+    or   r3, r4
+    or   r5, r6
+    or   r3, r5
+    jz .clobber_ok
+    report_fail error_message
+.clobber_ok:
+%ifidn %1, _emms
+    emms
+%elifnidn %1, _float
+    fstenv [esp]
+    cmp  word [esp + 8], 0xffff
+    je   .emms_ok
+    report_fail error_message_emms
+    emms
+.emms_ok:
+%endif
+    add  esp, max_args*4
+    REP_RET
+%endmacro
+
+%endif ; ARCH_X86_64
+
+CHECKED_CALL
+CHECKED_CALL _emms
+CHECKED_CALL _float

--- a/tests/checkasm/sdidec.c
+++ b/tests/checkasm/sdidec.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017 Open Broadcast Systems Ltd.
+ *
+ * Authors: James Darnley
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <libavutil/mem.h>
+
+#include "checkasm.h"
+#include "lib/upipe-hbrmt/sdidec.h"
+
+#define NUM_SAMPLES 512
+
+static void randomize_buffers(uint8_t *src0, uint8_t *src1)
+{
+    for (int i = 0; i < NUM_SAMPLES * 10 / 8; i++) {
+        uint8_t byte = rnd();
+        src0[i] = byte;
+        src1[i] = byte;
+    }
+}
+
+void checkasm_check_sdidec(void)
+{
+    struct {
+        void (*uyvy)(const uint8_t *src, uint16_t *dst, int64_t size);
+    } s = {
+        .uyvy = upipe_sdi_unpack_c,
+    };
+
+    int cpu_flags = av_get_cpu_flags();
+
+#if HAVE_X86ASM
+    if (cpu_flags & AV_CPU_FLAG_SSSE3) {
+        s.uyvy = upipe_sdi_unpack_10_ssse3;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX2) {
+        s.uyvy = upipe_sdi_unpack_10_avx2;
+    }
+#endif
+
+    if (check_func(s.uyvy, "sdi_to_uyvy")) {
+        uint8_t  src0[NUM_SAMPLES * 10 / 8];
+        uint8_t  src1[NUM_SAMPLES * 10 / 8];
+        DECLARE_ALIGNED(32, uint16_t, dst0)[NUM_SAMPLES];
+        DECLARE_ALIGNED(32, uint16_t, dst1)[NUM_SAMPLES];
+        declare_func(void, const uint8_t *src, uint16_t *dst, int64_t size);
+
+        randomize_buffers(src0, src1);
+        call_ref(src0, dst0, NUM_SAMPLES * 10 / 8);
+        call_new(src1, dst1, NUM_SAMPLES * 10 / 8);
+        if (memcmp(src0, src1, NUM_SAMPLES * 10 / 8)
+                || memcmp(dst0, dst1, NUM_SAMPLES))
+            fail();
+        bench_new(src1, dst1, NUM_SAMPLES * 10 / 8);
+    }
+    report("sdi_to_uyvy");
+}

--- a/tests/checkasm/sdienc.c
+++ b/tests/checkasm/sdienc.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2017 Open Broadcast Systems Ltd.
+ *
+ * Authors: James Darnley
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <libavutil/mem.h>
+
+#include "checkasm.h"
+#include "lib/upipe-hbrmt/sdienc.h"
+
+#define NUM_SAMPLES 512
+
+static void randomize_buffers(uint16_t *src0, uint16_t *src1)
+{
+    for (int i = 0; i < NUM_SAMPLES; i++) {
+        uint16_t sample = rnd() & 0x3ff;
+        src0[i] = sample;
+        src1[i] = sample;
+    }
+}
+
+void checkasm_check_sdienc(void)
+{
+    struct {
+        void (*uyvy)(uint8_t *dst, const uint8_t *src, int64_t samples);
+    } s = {
+        .uyvy = upipe_sdi_pack_c,
+    };
+
+    int cpu_flags = av_get_cpu_flags();
+
+#if HAVE_X86ASM
+    if (cpu_flags & AV_CPU_FLAG_SSSE3) {
+        s.uyvy = upipe_sdi_pack_10_ssse3;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX) {
+        s.uyvy = upipe_sdi_pack_10_avx;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX2) {
+        s.uyvy = upipe_sdi_pack_10_avx2;
+    }
+#endif
+
+    if (check_func(s.uyvy, "uyvy_to_sdi")) {
+        DECLARE_ALIGNED(16, uint16_t, src0)[NUM_SAMPLES];
+        DECLARE_ALIGNED(16, uint16_t, src1)[NUM_SAMPLES];
+        uint8_t dst0[NUM_SAMPLES * 10 / 8];
+        uint8_t dst1[NUM_SAMPLES * 10 / 8];
+        declare_func(void, uint8_t *dst, const uint8_t *src, int64_t samples);
+
+        randomize_buffers(src0, src1);
+        call_ref(dst0, (const uint8_t*)src0, NUM_SAMPLES);
+        call_new(dst1, (const uint8_t*)src1, NUM_SAMPLES);
+        if (memcmp(src0, src1, NUM_SAMPLES)
+                || memcmp(dst0, dst1, NUM_SAMPLES * 10 / 8))
+            fail();
+        bench_new(dst1, (const uint8_t*)src1, NUM_SAMPLES);
+    }
+    report("uyvy_to_sdi");
+}

--- a/tests/checkasm/timer.h
+++ b/tests/checkasm/timer.h
@@ -1,0 +1,139 @@
+/*
+ * copyright (c) 2006 Michael Niedermayer <michaelni@gmx.at>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file
+ * high precision timer, useful to profile code
+ */
+
+#ifndef AVUTIL_TIMER_H
+#define AVUTIL_TIMER_H
+
+#include "config.h"
+
+#if CONFIG_LINUX_PERF
+# ifndef _GNU_SOURCE
+#  define _GNU_SOURCE
+# endif
+# include <unistd.h> // read(3)
+# include <sys/ioctl.h>
+# include <asm/unistd.h>
+# include <linux/perf_event.h>
+#endif
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#if HAVE_MACH_ABSOLUTE_TIME
+#include <mach/mach_time.h>
+#endif
+
+#if   ARCH_AARCH64
+#   include "aarch64/timer.h"
+#elif ARCH_ARM
+#   include "arm/timer.h"
+#elif ARCH_PPC
+#   include "ppc/timer.h"
+#elif ARCH_X86
+#   include "timer_x86.h"
+#endif
+
+#if !defined(AV_READ_TIME)
+#   if HAVE_GETHRTIME
+#       define AV_READ_TIME gethrtime
+#   elif HAVE_MACH_ABSOLUTE_TIME
+#       define AV_READ_TIME mach_absolute_time
+#   endif
+#endif
+
+#ifndef FF_TIMER_UNITS
+#   define FF_TIMER_UNITS "UNITS"
+#endif
+
+#define TIMER_REPORT(id, tdiff)                                           \
+    {                                                                     \
+        static uint64_t tsum   = 0;                                       \
+        static int tcount      = 0;                                       \
+        static int tskip_count = 0;                                       \
+        static int thistogram[32] = {0};                                  \
+        thistogram[av_log2(tdiff)]++;                                     \
+        if (tcount < 2                ||                                  \
+            (tdiff) < 8 * tsum / tcount ||                                \
+            (tdiff) < 2000) {                                             \
+            tsum += (tdiff);                                              \
+            tcount++;                                                     \
+        } else                                                            \
+            tskip_count++;                                                \
+        if (((tcount + tskip_count) & (tcount + tskip_count - 1)) == 0) { \
+            int i;                                                        \
+            av_log(NULL, AV_LOG_ERROR,                                    \
+                   "%7"PRIu64" " FF_TIMER_UNITS " in %s,%8d runs,%7d skips",          \
+                   tsum * 10 / tcount, id, tcount, tskip_count);          \
+            for (i = 0; i < 32; i++)                                      \
+                av_log(NULL, AV_LOG_VERBOSE, " %2d", av_log2(2*thistogram[i]));\
+            av_log(NULL, AV_LOG_ERROR, "\n");                             \
+        }                                                                 \
+    }
+
+#if CONFIG_LINUX_PERF
+
+#define START_TIMER                                                         \
+    static int linux_perf_fd;                                               \
+    uint64_t tperf;                                                         \
+    if (!linux_perf_fd) {                                                   \
+        struct perf_event_attr attr = {                                     \
+            .type           = PERF_TYPE_HARDWARE,                           \
+            .size           = sizeof(struct perf_event_attr),               \
+            .config         = PERF_COUNT_HW_CPU_CYCLES,                     \
+            .disabled       = 1,                                            \
+            .exclude_kernel = 1,                                            \
+            .exclude_hv     = 1,                                            \
+        };                                                                  \
+        linux_perf_fd = syscall(__NR_perf_event_open, &attr,                \
+                                0, -1, -1, 0);                              \
+    }                                                                       \
+    if (linux_perf_fd == -1) {                                              \
+        av_log(NULL, AV_LOG_ERROR, "perf_event_open failed: %s\n",          \
+               av_err2str(AVERROR(errno)));                                 \
+    } else {                                                                \
+        ioctl(linux_perf_fd, PERF_EVENT_IOC_RESET, 0);                      \
+        ioctl(linux_perf_fd, PERF_EVENT_IOC_ENABLE, 0);                     \
+    }
+
+#define STOP_TIMER(id)                                                      \
+    ioctl(linux_perf_fd, PERF_EVENT_IOC_DISABLE, 0);                        \
+    read(linux_perf_fd, &tperf, sizeof(tperf));                             \
+    TIMER_REPORT(id, tperf)
+
+#elif defined(AV_READ_TIME)
+#define START_TIMER                             \
+    uint64_t tend;                              \
+    uint64_t tstart = AV_READ_TIME();           \
+
+#define STOP_TIMER(id)                                                    \
+    tend = AV_READ_TIME();                                                \
+    TIMER_REPORT(id, tend - tstart)
+#else
+#define START_TIMER
+#define STOP_TIMER(id) { }
+#endif
+
+#endif /* AVUTIL_TIMER_H */

--- a/tests/checkasm/timer_x86.h
+++ b/tests/checkasm/timer_x86.h
@@ -1,0 +1,50 @@
+/*
+ * copyright (c) 2006 Michael Niedermayer <michaelni@gmx.at>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_X86_TIMER_H
+#define AVUTIL_X86_TIMER_H
+
+#include <stdint.h>
+
+#if HAVE_INLINE_ASM
+
+#define FF_TIMER_UNITS "decicycles"
+#define AV_READ_TIME read_time
+
+static inline uint64_t read_time(void)
+{
+    uint32_t a, d;
+    __asm__ volatile(
+#if ARCH_X86_64 || defined(__SSE2__)
+                     "lfence \n\t"
+#endif
+                     "rdtsc  \n\t"
+                     : "=a" (a), "=d" (d));
+    return ((uint64_t)d << 32) + a;
+}
+
+#elif HAVE_RDTSC
+
+#include <intrin.h>
+#define AV_READ_TIME __rdtsc
+
+#endif /* HAVE_INLINE_ASM */
+
+#endif /* AVUTIL_X86_TIMER_H */

--- a/tests/checkasm/v210dec.c
+++ b/tests/checkasm/v210dec.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2015 Henrik Gramner
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <libavutil/intreadwrite.h>
+#include <libavutil/mem.h>
+
+#include "checkasm.h"
+#include "lib/upipe-v210/v210dec.h"
+
+static uint32_t clip(uint32_t value)
+{
+    if (value < 4)
+        return 4;
+    if (value > 1019)
+        return 1019;
+    return value;
+}
+
+static void write_v210(void *src0, void *src1)
+{
+    uint32_t t0 = rnd() & 0x3ff,
+             t1 = rnd() & 0x3ff,
+             t2 = rnd() & 0x3ff;
+    uint32_t value =  clip(t0)
+                   | (clip(t1) << 10)
+                   | (clip(t2) << 20);
+    AV_WL32(src0, value);
+    AV_WL32(src1, value);
+}
+
+#define BUF_SIZE 512
+
+static void randomize_buffers(void *src0, void *src1)
+{
+    for (int i = 0; i < BUF_SIZE * 8 / 3 / 4; i++) {
+        write_v210(src0, src1);
+        src0 += 4;
+        src1 += 4;
+    }
+}
+
+#define declare(type) \
+        type y0[BUF_SIZE]; \
+        type y1[BUF_SIZE]; \
+        type u0[BUF_SIZE / 2]; \
+        type u1[BUF_SIZE / 2]; \
+        type v0[BUF_SIZE / 2]; \
+        type v1[BUF_SIZE / 2]; \
+        DECLARE_ALIGNED(32, uint32_t, src0)[BUF_SIZE * 8 / 3 / 4]; \
+        DECLARE_ALIGNED(32, uint32_t, src1)[BUF_SIZE * 8 / 3 / 4]; \
+        declare_func(void, const void *src, type *y, type *u, type *v, ptrdiff_t width); \
+        ptrdiff_t width, step = 12 / sizeof(type)
+
+void checkasm_check_v210dec(void)
+{
+    struct {
+        void (*planar_10)(const void *src, uint16_t *y, uint16_t *u, uint16_t *v, uintptr_t pixels);
+        void (*planar_8)(const void *src, uint8_t *y, uint8_t *u, uint8_t *v, uintptr_t pixels);
+    } s = {
+        .planar_10 = upipe_v210_to_planar_10_c,
+        .planar_8  = upipe_v210_to_planar_8_c,
+    };
+
+    int cpu_flags = av_get_cpu_flags();
+
+#if HAVE_X86ASM
+    if (cpu_flags & AV_CPU_FLAG_SSSE3) {
+        s.planar_10 = upipe_v210_to_planar_10_aligned_ssse3;
+        s.planar_8  = upipe_v210_to_planar_8_aligned_ssse3;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX) {
+        s.planar_10 = upipe_v210_to_planar_10_aligned_avx;
+        s.planar_8  = upipe_v210_to_planar_8_aligned_avx;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX2) {
+        s.planar_10 = upipe_v210_to_planar_10_aligned_avx2;
+        s.planar_8  = upipe_v210_to_planar_8_aligned_avx2;
+    }
+#endif
+
+    if (check_func(s.planar_8, "v210_to_planar8")) {
+        declare(uint8_t);
+        for (width = step; width < BUF_SIZE - 15; width += step) {
+            randomize_buffers(src0, src1);
+            call_ref(src0, y0, u0, v0, width);
+            call_new(src1, y1, u1, v1, width);
+            if (memcmp(y0, y1, width) || memcmp(u0, u1, width / 2) || memcmp(v0, v1, width / 2))
+                fail();
+            bench_new(src1, y1, u1, v1, width);
+        }
+    }
+    report("v210_to_planar8");
+
+    if (check_func(s.planar_10, "v210_to_planar10")) {
+        declare(uint16_t);
+        for (width = step; width < BUF_SIZE - 15; width += step) {
+            randomize_buffers(src0, src1);
+            call_ref(src0, y0, u0, v0, width);
+            call_new(src1, y1, u1, v1, width);
+            if (memcmp(y0, y1, width) || memcmp(u0, u1, width / 2) || memcmp(v0, v1, width / 2))
+                fail();
+            bench_new(src1, y1, u1, v1, width);
+        }
+    }
+    report("v210_to_planar10");
+}

--- a/tests/checkasm/v210enc.c
+++ b/tests/checkasm/v210enc.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2015 Henrik Gramner
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with FFmpeg; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <string.h>
+#include <libavutil/intreadwrite.h>
+
+#include "checkasm.h"
+#include "lib/upipe-v210/v210enc.h"
+
+#define BUF_SIZE 512
+
+#define randomize_buffers(mask)                        \
+    do {                                               \
+        int i, size = sizeof(*y0);                     \
+        for (i = 0; i < BUF_SIZE; i += 4 / size) {     \
+            uint32_t r = rnd() & mask;                 \
+            AV_WN32A(y0 + i, r);                       \
+            AV_WN32A(y1 + i, r);                       \
+        }                                              \
+        for (i = 0; i < BUF_SIZE / 2; i += 4 / size) { \
+            uint32_t r = rnd() & mask;                 \
+            AV_WN32A(u0 + i, r);                       \
+            AV_WN32A(u1 + i, r);                       \
+            r = rnd() & mask;                          \
+            AV_WN32A(v0 + i, r);                       \
+            AV_WN32A(v1 + i, r);                       \
+        }                                              \
+        for (i = 0; i < width * 8 / 3; i += 4) {       \
+            uint32_t r = rnd();                        \
+            AV_WN32A(dst0 + i, r);                     \
+            AV_WN32A(dst1 + i, r);                     \
+        }                                              \
+    } while (0)
+
+#define check_pack_line(type, mask)                                                \
+    do {                                                                           \
+        type y0[BUF_SIZE];                                                         \
+        type y1[BUF_SIZE];                                                         \
+        type u0[BUF_SIZE / 2];                                                     \
+        type u1[BUF_SIZE / 2];                                                     \
+        type v0[BUF_SIZE / 2];                                                     \
+        type v1[BUF_SIZE / 2];                                                     \
+        uint8_t dst0[BUF_SIZE * 8 / 3];                                            \
+        uint8_t dst1[BUF_SIZE * 8 / 3];                                            \
+                                                                                   \
+        declare_func(void, const type * y, const type * u, const type * v,         \
+                     uint8_t * dst, ptrdiff_t width);                              \
+        ptrdiff_t width, step = 12 / sizeof(type);                                 \
+                                                                                   \
+        for (width = step; width < BUF_SIZE - 15; width += step) {                 \
+            int y_offset  = rnd() & 15;                                            \
+            int uv_offset = y_offset / 2;                                          \
+            randomize_buffers(mask);                                               \
+            call_ref(y0 + y_offset, u0 + uv_offset, v0 + uv_offset, dst0, width);  \
+            call_new(y1 + y_offset, u1 + uv_offset, v1 + uv_offset, dst1, width);  \
+            if (memcmp(y0, y1, BUF_SIZE) || memcmp(u0, u1, BUF_SIZE / 2) ||        \
+                memcmp(v0, v1, BUF_SIZE / 2) || memcmp(dst0, dst1, width * 8 / 3)) \
+                fail();                                                            \
+            bench_new(y1 + y_offset, u1 + uv_offset, v1 + uv_offset, dst1, width); \
+        }                                                                          \
+    } while (0)
+
+void checkasm_check_v210enc(void)
+{
+    struct {
+        void (*planar_10)(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width);
+        void (*planar_8)(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width);
+    } s = {
+        .planar_10 = upipe_v210enc_planar_pack_10_c,
+        .planar_8  = upipe_v210enc_planar_pack_8_c,
+    };
+
+    int cpu_flags = av_get_cpu_flags();
+
+#if HAVE_X86ASM
+    if (cpu_flags & AV_CPU_FLAG_SSSE3) {
+        s.planar_10 = upipe_v210_planar_pack_10_ssse3;
+        s.planar_8  = upipe_v210_planar_pack_8_ssse3;
+    }
+    if (cpu_flags & AV_CPU_FLAG_AVX)
+        s.planar_8  = upipe_v210_planar_pack_8_avx;
+    if (cpu_flags & AV_CPU_FLAG_AVX2) {
+        s.planar_10 = upipe_v210_planar_pack_10_avx2;
+        s.planar_8  = upipe_v210_planar_pack_8_avx2;
+    }
+#endif
+
+    if (check_func(s.planar_8, "planar8_to_v210"))
+        check_pack_line(uint8_t, 0xffffffff);
+    report("planar8_to_v210");
+
+    if (check_func(s.planar_10, "planar10_to_v210"))
+        check_pack_line(uint16_t, 0x03ff03ff);
+    report("planar10_to_v210");
+}


### PR DESCRIPTION
For those unaware this utility is a great platform on which to test SIMD functions.  It iterates over a list of functions and calls each after forcing CPU feature flags to be each one available on the host.  Each function in the list called is a specially written function that: sets up data structures needed to run a reference and tested functions; creates input data; runs both the reference and tested functions; checks whether the output is correct, usually whether it is identical to the reference output; finally it reports the status to the main program.  It also provides an option to benchmark the functions

This PR is intended to get comments on adopting this into Upipe.