### PR TITLE
Improve assembly functions

### DIFF
--- a/lib/upipe-hbrmt/sdidec.asm
+++ b/lib/upipe-hbrmt/sdidec.asm
@@ -54,10 +54,10 @@ planar_8_y_shuf_after: db 1, 3, 5, 7, 9, 11, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 
 SECTION .text
 
-%macro sdi_unpack_10 0
+%macro sdi_to_uyvy 0
 
-; sdi_unpack_10(const uint8_t *src, uint16_t *y, int64_t size)
-cglobal sdi_unpack_10, 3, 3, 7, src, y, size
+; sdi_to_uyvy(const uint8_t *src, uint16_t *y, int64_t size)
+cglobal sdi_to_uyvy, 3, 3, 7, src, y, size
     add      srcq, sizeq
     neg      sizeq
 
@@ -94,9 +94,9 @@ cglobal sdi_unpack_10, 3, 3, 7, src, y, size
 %endmacro
 
 INIT_XMM ssse3
-sdi_unpack_10
+sdi_to_uyvy
 INIT_YMM avx2
-sdi_unpack_10
+sdi_to_uyvy
 
 %macro sdi_v210_unpack 0
 

--- a/lib/upipe-hbrmt/sdidec.c
+++ b/lib/upipe-hbrmt/sdidec.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include "sdidec.h"
 
-void upipe_sdi_unpack_c(const uint8_t *src, uint16_t *y, int64_t size)
+void upipe_sdi_to_uyvy_c(const uint8_t *src, uint16_t *y, int64_t size)
 {
     uint64_t pixels = size * 8 /10;
 

--- a/lib/upipe-hbrmt/sdidec.h
+++ b/lib/upipe-hbrmt/sdidec.h
@@ -1,3 +1,3 @@
-void upipe_sdi_unpack_c(const uint8_t *src, uint16_t *y, int64_t size);
-void upipe_sdi_unpack_10_ssse3(const uint8_t *src, uint16_t *y, int64_t size);
-void upipe_sdi_unpack_10_avx2 (const uint8_t *src, uint16_t *y, int64_t size);
+void upipe_sdi_to_uyvy_c(const uint8_t *src, uint16_t *y, int64_t size);
+void upipe_sdi_to_uyvy_ssse3(const uint8_t *src, uint16_t *y, int64_t size);
+void upipe_sdi_to_uyvy_avx2 (const uint8_t *src, uint16_t *y, int64_t size);

--- a/lib/upipe-hbrmt/sdienc.asm
+++ b/lib/upipe-hbrmt/sdienc.asm
@@ -58,10 +58,10 @@ pb_0: times 32 db 0
 
 SECTION .text
 
-%macro sdi_pack_10 0
+%macro uyvy_to_sdi 0
 
-; sdi_pack_10(uint8_t *dst, const uint8_t *y, int64_t size)
-cglobal sdi_pack_10, 3, 4, 3, dst, y, size
+; uyvy_to_sdi(uint8_t *dst, const uint8_t *y, int64_t size)
+cglobal uyvy_to_sdi, 3, 4, 3, dst, y, size
     add     sizeq, sizeq
     add     yq, sizeq
     neg     sizeq
@@ -86,11 +86,11 @@ cglobal sdi_pack_10, 3, 4, 3, dst, y, size
 %endmacro
 
 INIT_XMM ssse3
-sdi_pack_10
+uyvy_to_sdi
 INIT_XMM avx
-sdi_pack_10
+uyvy_to_sdi
 INIT_YMM avx2
-sdi_pack_10
+uyvy_to_sdi
 
 %macro sdi_blank 0
 

--- a/lib/upipe-hbrmt/sdienc.c
+++ b/lib/upipe-hbrmt/sdienc.c
@@ -24,7 +24,7 @@
 
 #include "sdienc.h"
 
-void upipe_sdi_pack_c(uint8_t *dst, const uint8_t *y, int64_t size)
+void upipe_uyvy_to_sdi_c(uint8_t *dst, const uint8_t *y, int64_t size)
 {
     struct ubits s;
     ubits_init(&s, dst, size * 10 / 8);

--- a/lib/upipe-hbrmt/sdienc.h
+++ b/lib/upipe-hbrmt/sdienc.h
@@ -1,4 +1,4 @@
-void upipe_sdi_pack_c(uint8_t *dst, const uint8_t *y, int64_t size);
-void upipe_sdi_pack_10_ssse3(uint8_t *dst, const uint8_t *y, int64_t size);
-void upipe_sdi_pack_10_avx  (uint8_t *dst, const uint8_t *y, int64_t size);
-void upipe_sdi_pack_10_avx2 (uint8_t *dst, const uint8_t *y, int64_t size);
+void upipe_uyvy_to_sdi_c(uint8_t *dst, const uint8_t *y, int64_t size);
+void upipe_uyvy_to_sdi_ssse3(uint8_t *dst, const uint8_t *y, int64_t size);
+void upipe_uyvy_to_sdi_avx  (uint8_t *dst, const uint8_t *y, int64_t size);
+void upipe_uyvy_to_sdi_avx2 (uint8_t *dst, const uint8_t *y, int64_t size);

--- a/lib/upipe-hbrmt/upipe_pack10bit.c
+++ b/lib/upipe-hbrmt/upipe_pack10bit.c
@@ -329,18 +329,18 @@ static struct upipe *upipe_pack10bit_alloc(struct upipe_mgr *mgr,
 
     struct upipe_pack10bit *upipe_pack10bit = upipe_pack10bit_from_upipe(upipe);
 
-    upipe_pack10bit->pack = upipe_sdi_pack_c;
+    upipe_pack10bit->pack = upipe_uyvy_to_sdi_c;
 
 #if defined(HAVE_X86ASM)
 #if defined(__i686__) || defined(__x86_64__)
     if (__builtin_cpu_supports("ssse3"))
-        upipe_pack10bit->pack = upipe_sdi_pack_10_ssse3;
+        upipe_pack10bit->pack = upipe_uyvy_to_sdi_ssse3;
 
     if (__builtin_cpu_supports("avx"))
-        upipe_pack10bit->pack = upipe_sdi_pack_10_avx;
+        upipe_pack10bit->pack = upipe_uyvy_to_sdi_avx;
 
     if (__builtin_cpu_supports("avx2"))
-        upipe_pack10bit->pack = upipe_sdi_pack_10_avx2;
+        upipe_pack10bit->pack = upipe_uyvy_to_sdi_avx2;
 #endif
 #endif
 

--- a/lib/upipe-hbrmt/upipe_unpack10bit.c
+++ b/lib/upipe-hbrmt/upipe_unpack10bit.c
@@ -330,14 +330,14 @@ static struct upipe *upipe_unpack10bit_alloc(struct upipe_mgr *mgr,
 
     struct upipe_unpack10bit *upipe_unpack10bit = upipe_unpack10bit_from_upipe(upipe);
 
-    upipe_unpack10bit->unpack = upipe_sdi_unpack_c;
+    upipe_unpack10bit->unpack = upipe_sdi_to_uyvy_c;
 #if defined(HAVE_X86ASM)
 #if defined(__i686__) || defined(__x86_64__)
     if (__builtin_cpu_supports("ssse3"))
-        upipe_unpack10bit->unpack = upipe_sdi_unpack_10_ssse3;
+        upipe_unpack10bit->unpack = upipe_sdi_to_uyvy_ssse3;
 
     if (__builtin_cpu_supports("avx2"))
-        upipe_unpack10bit->unpack = upipe_sdi_unpack_10_avx2;
+        upipe_unpack10bit->unpack = upipe_sdi_to_uyvy_avx2;
 #endif
 #endif
 

--- a/lib/upipe-v210/upipe_v210enc.c
+++ b/lib/upipe-v210/upipe_v210enc.c
@@ -582,16 +582,16 @@ static struct upipe *upipe_v210enc_alloc(struct upipe_mgr *mgr,
 
 #if defined(HAVE_X86ASM)
 #if defined(__i686__) || defined(__x86_64__)
+    if (__builtin_cpu_supports("ssse3")) {
+        upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_ssse3;
+        upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_ssse3;
+    }
+    if (__builtin_cpu_supports("avx"))
+        upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_avx;
+
     if (__builtin_cpu_supports("avx2")) {
         upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_avx2;
         upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_avx2;
-    } else {
-        if (__builtin_cpu_supports("ssse3")) {
-            upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_ssse3;
-            upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_ssse3;
-        }
-        if (__builtin_cpu_supports("avx"))
-            upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_avx;
     }
 #endif
 #endif

--- a/lib/upipe-v210/upipe_v210enc.c
+++ b/lib/upipe-v210/upipe_v210enc.c
@@ -577,21 +577,21 @@ static struct upipe *upipe_v210enc_alloc(struct upipe_mgr *mgr,
 
     struct upipe_v210enc *upipe_v210enc = upipe_v210enc_from_upipe(upipe);
 
-    upipe_v210enc->pack_line_8  = upipe_v210enc_planar_pack_8_c;
-    upipe_v210enc->pack_line_10 = upipe_v210enc_planar_pack_10_c;
+    upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_c;
+    upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_c;
 
 #if defined(HAVE_X86ASM)
 #if defined(__i686__) || defined(__x86_64__)
     if (__builtin_cpu_supports("avx2")) {
-        upipe_v210enc->pack_line_8  = upipe_v210_planar_pack_8_avx2;
-        upipe_v210enc->pack_line_10 = upipe_v210_planar_pack_10_avx2;
+        upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_avx2;
+        upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_avx2;
     } else {
         if (__builtin_cpu_supports("ssse3")) {
-            upipe_v210enc->pack_line_8  = upipe_v210_planar_pack_8_ssse3;
-            upipe_v210enc->pack_line_10 = upipe_v210_planar_pack_10_ssse3;
+            upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_ssse3;
+            upipe_v210enc->pack_line_10 = upipe_planar_to_v210_10_ssse3;
         }
         if (__builtin_cpu_supports("avx"))
-            upipe_v210enc->pack_line_8  = upipe_v210_planar_pack_8_avx;
+            upipe_v210enc->pack_line_8  = upipe_planar_to_v210_8_avx;
     }
 #endif
 #endif

--- a/lib/upipe-v210/v210enc.asm
+++ b/lib/upipe-v210/v210enc.asm
@@ -43,12 +43,6 @@ v210_enc_chroma_shuf2_8: times 2 db 3,-1,4,-1,5,-1,7,-1,11,-1,12,-1,13,-1,15,-1
 
 v210_enc_chroma_mult_8: times 2 dw 4,16,64,0,64,4,16,0
 
-v210_enc_uyvy_chroma_shift_10: times 2 dw 1, 0, 16, 0, 4, 0, 0, 0
-v210_enc_uyvy_chroma_shuff_10: times 2 db 0, 1, 4, 5, -1, 8, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1
-
-v210_enc_uyvy_luma_shift_10: times 2 dw 0, 4, 0, 1, 0, 16, 0, 0
-v210_enc_uyvy_luma_shuft_10: times 2 db -1, 2, 3, -1, 6, 7, 10, 11, -1, -1, -1, -1, -1, -1, -1, -1
-
 SECTION .text
 
 %macro planar_to_v210_10 0
@@ -101,52 +95,6 @@ planar_to_v210_10
 
 INIT_YMM avx2
 planar_to_v210_10
-
-%macro v210_uyvy_pack_10 0
-
-; v210_uyvy_pack_10(const uint16_t *y, uint8_t *dst, ptrdiff_t width)
-cglobal v210_uyvy_pack_10, 3, 6, 6, y, dst, width
-    shl     widthq, 2
-    add     yq, widthq
-    neg     widthq
-
-    mova    m4, [v210_enc_min_10]
-    mova    m5, [v210_enc_max_10]
-
-.loop:
-    movu    m0, [yq+widthq+ 0]
-    movu    m1, [yq+widthq+12]
-
-    CLIPW   m0, m4, m5
-    CLIPW   m1, m4, m5
-
-    pmullw  m2, m0, [v210_enc_uyvy_luma_shift_10]
-    pmullw  m3, m1, [v210_enc_uyvy_luma_shift_10]
-
-    pmullw  m0, [v210_enc_uyvy_chroma_shift_10]
-    pshufb  m0, [v210_enc_uyvy_chroma_shuff_10]
-
-    pmullw  m1, [v210_enc_uyvy_chroma_shift_10]
-    pshufb  m1, [v210_enc_uyvy_chroma_shuff_10]
-
-    pshufb  m2, [v210_enc_uyvy_luma_shuft_10]
-    pshufb  m3, [v210_enc_uyvy_luma_shuft_10]
-
-    por     m0, m2
-    por     m1, m3
-
-    movu    [dstq+0], m0
-    movq    [dstq+8], m1
-
-    add     dstq, mmsize
-    add     widthq, 24
-    jl .loop
-
-    RET
-%endmacro
-
-INIT_XMM ssse3
-v210_uyvy_pack_10
 
 %macro planar_to_v210_8 0
 

--- a/lib/upipe-v210/v210enc.asm
+++ b/lib/upipe-v210/v210enc.asm
@@ -51,10 +51,10 @@ v210_enc_uyvy_luma_shuft_10: times 2 db -1, 2, 3, -1, 6, 7, 10, 11, -1, -1, -1, 
 
 SECTION .text
 
-%macro v210_planar_pack_10 0
+%macro planar_to_v210_10 0
 
-; v210_planar_pack_10(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width)
-cglobal v210_planar_pack_10, 5, 5, 4+cpuflag(avx2), y, u, v, dst, width
+; planar_to_v210_10(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width)
+cglobal planar_to_v210_10, 5, 5, 4+cpuflag(avx2), y, u, v, dst, width
     lea     r0, [yq+2*widthq]
     add     uq, widthq
     add     vq, widthq
@@ -97,10 +97,10 @@ cglobal v210_planar_pack_10, 5, 5, 4+cpuflag(avx2), y, u, v, dst, width
 %endmacro
 
 INIT_XMM ssse3
-v210_planar_pack_10
+planar_to_v210_10
 
 INIT_YMM avx2
-v210_planar_pack_10
+planar_to_v210_10
 
 %macro v210_uyvy_pack_10 0
 
@@ -148,10 +148,10 @@ cglobal v210_uyvy_pack_10, 3, 6, 6, y, dst, width
 INIT_XMM ssse3
 v210_uyvy_pack_10
 
-%macro v210_planar_pack_8 0
+%macro planar_to_v210_8 0
 
-; v210_planar_pack_8(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width)
-cglobal v210_planar_pack_8, 5, 5, 7, y, u, v, dst, width
+; planar_to_v210_8(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width)
+cglobal planar_to_v210_8, 5, 5, 7, y, u, v, dst, width
     add     yq, widthq
     shr     widthq, 1
     add     uq, widthq
@@ -215,8 +215,8 @@ cglobal v210_planar_pack_8, 5, 5, 7, y, u, v, dst, width
 %endmacro
 
 INIT_XMM ssse3
-v210_planar_pack_8
+planar_to_v210_8
 INIT_XMM avx
-v210_planar_pack_8
+planar_to_v210_8
 INIT_YMM avx2
-v210_planar_pack_8
+planar_to_v210_8

--- a/lib/upipe-v210/v210enc.c
+++ b/lib/upipe-v210/v210enc.c
@@ -59,7 +59,7 @@ static inline void wl32(uint8_t *dst, uint32_t u)
         dst += 4;                       \
     } while (0)
 
-void upipe_v210enc_planar_pack_8_c(const uint8_t *y, const uint8_t *u,
+void upipe_planar_to_v210_8_c(const uint8_t *y, const uint8_t *u,
                                  const uint8_t *v, uint8_t *dst, ptrdiff_t width)
 {
     uint32_t val;
@@ -78,7 +78,7 @@ void upipe_v210enc_planar_pack_8_c(const uint8_t *y, const uint8_t *u,
     }
 }
 
-void upipe_v210enc_planar_pack_10_c(const uint16_t *y, const uint16_t *u,
+void upipe_planar_to_v210_10_c(const uint16_t *y, const uint16_t *u,
                                   const uint16_t *v, uint8_t *dst, ptrdiff_t width)
 {
     uint32_t val;

--- a/lib/upipe-v210/v210enc.h
+++ b/lib/upipe-v210/v210enc.h
@@ -1,15 +1,15 @@
 #include <inttypes.h>
 
-void upipe_v210enc_planar_pack_8_c(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width);
-void upipe_v210enc_planar_pack_10_c(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width);
+void upipe_planar_to_v210_8_c(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width);
+void upipe_planar_to_v210_10_c(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width);
 
-void upipe_v210_planar_pack_10_avx2(const uint16_t *y, const uint16_t *u,
+void upipe_planar_to_v210_10_avx2(const uint16_t *y, const uint16_t *u,
                                     const uint16_t *v, uint8_t *dst, ptrdiff_t width);
-void upipe_v210_planar_pack_10_ssse3(const uint16_t *y, const uint16_t *u,
+void upipe_planar_to_v210_10_ssse3(const uint16_t *y, const uint16_t *u,
                                      const uint16_t *v, uint8_t *dst, ptrdiff_t width);
-void upipe_v210_planar_pack_8_ssse3(const uint8_t *y, const uint8_t *u,
+void upipe_planar_to_v210_8_ssse3(const uint8_t *y, const uint8_t *u,
                                     const uint8_t *v, uint8_t *dst, ptrdiff_t width);
-void upipe_v210_planar_pack_8_avx(const uint8_t *y, const uint8_t *u,
+void upipe_planar_to_v210_8_avx(const uint8_t *y, const uint8_t *u,
                                   const uint8_t *v, uint8_t *dst, ptrdiff_t width);
-void upipe_v210_planar_pack_8_avx2(const uint8_t *y, const uint8_t *u,
+void upipe_planar_to_v210_8_avx2(const uint8_t *y, const uint8_t *u,
                                    const uint8_t *v, uint8_t *dst, ptrdiff_t width);

--- a/tests/checkasm/sdidec.c
+++ b/tests/checkasm/sdidec.c
@@ -40,17 +40,17 @@ void checkasm_check_sdidec(void)
     struct {
         void (*uyvy)(const uint8_t *src, uint16_t *dst, int64_t size);
     } s = {
-        .uyvy = upipe_sdi_unpack_c,
+        .uyvy = upipe_sdi_to_uyvy_c,
     };
 
     int cpu_flags = av_get_cpu_flags();
 
 #if HAVE_X86ASM
     if (cpu_flags & AV_CPU_FLAG_SSSE3) {
-        s.uyvy = upipe_sdi_unpack_10_ssse3;
+        s.uyvy = upipe_sdi_to_uyvy_ssse3;
     }
     if (cpu_flags & AV_CPU_FLAG_AVX2) {
-        s.uyvy = upipe_sdi_unpack_10_avx2;
+        s.uyvy = upipe_sdi_to_uyvy_avx2;
     }
 #endif
 

--- a/tests/checkasm/sdienc.c
+++ b/tests/checkasm/sdienc.c
@@ -40,20 +40,20 @@ void checkasm_check_sdienc(void)
     struct {
         void (*uyvy)(uint8_t *dst, const uint8_t *src, int64_t samples);
     } s = {
-        .uyvy = upipe_sdi_pack_c,
+        .uyvy = upipe_uyvy_to_sdi_c,
     };
 
     int cpu_flags = av_get_cpu_flags();
 
 #if HAVE_X86ASM
     if (cpu_flags & AV_CPU_FLAG_SSSE3) {
-        s.uyvy = upipe_sdi_pack_10_ssse3;
+        s.uyvy = upipe_uyvy_to_sdi_ssse3;
     }
     if (cpu_flags & AV_CPU_FLAG_AVX) {
-        s.uyvy = upipe_sdi_pack_10_avx;
+        s.uyvy = upipe_uyvy_to_sdi_avx;
     }
     if (cpu_flags & AV_CPU_FLAG_AVX2) {
-        s.uyvy = upipe_sdi_pack_10_avx2;
+        s.uyvy = upipe_uyvy_to_sdi_avx2;
     }
 #endif
 

--- a/tests/checkasm/v210enc.c
+++ b/tests/checkasm/v210enc.c
@@ -83,30 +83,30 @@ void checkasm_check_v210enc(void)
         void (*planar_10)(const uint16_t *y, const uint16_t *u, const uint16_t *v, uint8_t *dst, ptrdiff_t width);
         void (*planar_8)(const uint8_t *y, const uint8_t *u, const uint8_t *v, uint8_t *dst, ptrdiff_t width);
     } s = {
-        .planar_10 = upipe_v210enc_planar_pack_10_c,
-        .planar_8  = upipe_v210enc_planar_pack_8_c,
+        .planar_10 = upipe_planar_to_v210_10_c,
+        .planar_8  = upipe_planar_to_v210_8_c,
     };
 
     int cpu_flags = av_get_cpu_flags();
 
 #if HAVE_X86ASM
     if (cpu_flags & AV_CPU_FLAG_SSSE3) {
-        s.planar_10 = upipe_v210_planar_pack_10_ssse3;
-        s.planar_8  = upipe_v210_planar_pack_8_ssse3;
+        s.planar_10 = upipe_planar_to_v210_10_ssse3;
+        s.planar_8  = upipe_planar_to_v210_8_ssse3;
     }
     if (cpu_flags & AV_CPU_FLAG_AVX)
-        s.planar_8  = upipe_v210_planar_pack_8_avx;
+        s.planar_8  = upipe_planar_to_v210_8_avx;
     if (cpu_flags & AV_CPU_FLAG_AVX2) {
-        s.planar_10 = upipe_v210_planar_pack_10_avx2;
-        s.planar_8  = upipe_v210_planar_pack_8_avx2;
+        s.planar_10 = upipe_planar_to_v210_10_avx2;
+        s.planar_8  = upipe_planar_to_v210_8_avx2;
     }
 #endif
 
-    if (check_func(s.planar_8, "planar8_to_v210"))
+    if (check_func(s.planar_8, "planar_to_v210_8"))
         check_pack_line(uint8_t, 0xffffffff);
-    report("planar8_to_v210");
+    report("planar_to_v210_8");
 
-    if (check_func(s.planar_10, "planar10_to_v210"))
+    if (check_func(s.planar_10, "planar_to_v210_10"))
         check_pack_line(uint16_t, 0x03ff03ff);
-    report("planar10_to_v210");
+    report("planar_to_v210_10");
 }


### PR DESCRIPTION
First harmonize function names in the form X_to_Y.  Next remove an unused function I saw while doing that.  Finally simplify odd if-else-if-if block for choosing functions.