### PR TITLE
checkasm: link objects directly

### DIFF
--- a/tests/checkasm/Makefile.am
+++ b/tests/checkasm/Makefile.am
@@ -4,8 +4,14 @@ TESTS = checkasm
 
 checkasm_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include -I$(top_builddir) -I$(top_builddir)/include $(AVUTIL_CFLAGS)
 checkasm_LDADD = $(LDADD) $(AVUTIL_LIBS) \
-    $(top_builddir)/lib/upipe-hbrmt/libupipe_hbrmt.la \
-    $(top_builddir)/lib/upipe-v210/libupipe_v210.la
+    $(top_builddir)/lib/upipe-hbrmt/libupipe_hbrmt_la-sdidec.o \
+    $(top_builddir)/lib/upipe-hbrmt/libupipe_hbrmt_la-sdienc.o \
+    $(top_builddir)/lib/upipe-hbrmt/sdidec.o \
+    $(top_builddir)/lib/upipe-hbrmt/sdienc.o \
+    $(top_builddir)/lib/upipe-v210/libupipe_v210_la-v210dec.o \
+    $(top_builddir)/lib/upipe-v210/libupipe_v210_la-v210enc.o \
+    $(top_builddir)/lib/upipe-v210/v210dec.o \
+    $(top_builddir)/lib/upipe-v210/v210enc.o
 
 checkasm_SOURCES = checkasm.c checkasm.h timer.h \
     sdidec.c \

--- a/tests/checkasm/sdienc.c
+++ b/tests/checkasm/sdienc.c
@@ -60,8 +60,8 @@ void checkasm_check_sdienc(void)
     if (check_func(s.uyvy, "uyvy_to_sdi")) {
         DECLARE_ALIGNED(16, uint16_t, src0)[NUM_SAMPLES];
         DECLARE_ALIGNED(16, uint16_t, src1)[NUM_SAMPLES];
-        uint8_t dst0[NUM_SAMPLES * 10 / 8];
-        uint8_t dst1[NUM_SAMPLES * 10 / 8];
+        uint8_t dst0[NUM_SAMPLES * 10 / 8 + 32];
+        uint8_t dst1[NUM_SAMPLES * 10 / 8 + 32];
         declare_func(void, uint8_t *dst, const uint8_t *src, int64_t pixels);
 
         randomize_buffers(src0, src1);


### PR DESCRIPTION
The functions we need are not visible when building shared libraries on
Linux or ELF causng a linking error.