### PR TITLE
upipe: fix upipe_*_alloc_output double release

### DIFF
--- a/include/upipe/upipe.h
+++ b/include/upipe/upipe.h
@@ -1648,10 +1648,8 @@ static inline struct upipe *                                                \
                                  struct uprobe *uprobe  ARGS_DECL)          \
 {                                                                           \
     struct upipe *output = upipe_##GROUP##_alloc(upipe_mgr, uprobe  ARGS);  \
-    if (unlikely(output == NULL)) {                                         \
-        uprobe_release(uprobe);                                             \
+    if (unlikely(output == NULL))                                           \
         return NULL;                                                        \
-    }                                                                       \
     if (unlikely(!ubase_check(upipe_set_output(upipe, output)))) {          \
         upipe_release(output);                                              \
         return NULL;                                                        \


### PR DESCRIPTION
Don't release probe in upipe_*_alloc_output because upipe_*_alloc is
responsible for it if it fails.