### PR TITLE
upump: add restart control for timers

### DIFF
--- a/include/upipe/upump.h
+++ b/include/upipe/upump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 OpenHeadend S.A.R.L.
+ * Copyright (C) 2012-2018 OpenHeadend S.A.R.L.
  *
  * Authors: Christophe Massiot
  *
@@ -90,6 +90,8 @@ enum upump_command {
     UPUMP_ALLOC_BLOCKER,
     /** frees a blocker (struct upump_blocker *) */
     UPUMP_FREE_BLOCKER,
+    /** restarts the pump (void) */
+    UPUMP_RESTART,
 
     /** non-standard commands implemented by a upump handler can start
      * from there (first arg = signature) */
@@ -342,6 +344,18 @@ static inline void upump_start(struct upump *upump)
 static inline void upump_stop(struct upump *upump)
 {
     upump_control(upump, UPUMP_STOP);
+}
+
+/** @This asks the event loop to restart a timer pump.
+ * The timer will be restart to its initial value, as if it was stop, set to
+ * its inital value and start. This could be useful to implement IO timeout
+ * without freeing and allocating a pump each time data is received.
+ *
+ * @param pump description structure of the pump
+ */
+static inline void upump_restart(struct upump *upump)
+{
+    upump_control(upump, UPUMP_RESTART);
 }
 
 /** @This frees a upump structure.

--- a/include/upipe/upump_common.h
+++ b/include/upipe/upump_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 OpenHeadend S.A.R.L.
+ * Copyright (C) 2012-2018 OpenHeadend S.A.R.L.
  *
  * Authors: Christophe Massiot
  *
@@ -92,6 +92,12 @@ void upump_common_dispatch(struct upump *upump);
  */
 void upump_common_start(struct upump *upump);
 
+/** @This restarts a pump if allowed.
+ *
+ * @param upump description structure of the pump
+ */
+void upump_common_restart(struct upump *upump);
+
 /** @This stops a pump if needed.
  *
  * @param upump description structure of the pump
@@ -129,6 +135,8 @@ struct upump_common_mgr {
 
     /** function to really start a watcher */
     void (*upump_real_start)(struct upump *, bool);
+    /** function to really restart a watcher */
+    void (*upump_real_restart)(struct upump *, bool);
     /** function to really stop a watcher */
     void (*upump_real_stop)(struct upump *, bool);
 
@@ -175,6 +183,7 @@ void upump_common_mgr_clean(struct upump_mgr *mgr);
  * @param pool_extra extra buffer space (see @ref upump_common_mgr_sizeof)
  * @param upump_real_start function of the real manager that starts a pump
  * @param upump_real_stop function of the real manager that stops a pump
+ * @param upump_real_restart function of the real manager that restarts a pump
  * @param upump_alloc_inner function to call to allocate a upump buffer
  * @param upump_free_inner function to call to release a upump buffer
  */
@@ -183,6 +192,7 @@ void upump_common_mgr_init(struct upump_mgr *mgr,
                            uint16_t upump_blocker_pool_depth, void *pool_extra,
                            void (*upump_real_start)(struct upump *, bool),
                            void (*upump_real_stop)(struct upump *, bool),
+                           void (*upump_real_restart)(struct upump *, bool),
                            void *(*upump_alloc_inner)(struct upool *),
                            void (*upump_free_inner)(struct upool *, void *));
 

--- a/lib/upipe/upump_common.c
+++ b/lib/upipe/upump_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2017 OpenHeadend S.A.R.L.
+ * Copyright (C) 2012-2018 OpenHeadend S.A.R.L.
  *
  * Authors: Christophe Massiot
  *
@@ -160,6 +160,21 @@ void upump_common_start(struct upump *upump)
     }
 }
 
+/** @This restarts a pump if allowed.
+ *
+ * @param upump description structure of the pump
+ */
+void upump_common_restart(struct upump *upump)
+{
+    struct upump_common *common = upump_common_from_upump(upump);
+    common->started = true;
+    if (ulist_empty(&common->blockers)) {
+        struct upump_common_mgr *common_mgr =
+            upump_common_mgr_from_upump_mgr(upump->mgr);
+        common_mgr->upump_real_restart(upump, common->status);
+    }
+}
+
 /** @This stops a pump if needed.
  *
  * @param upump description structure of the pump
@@ -270,6 +285,7 @@ void upump_common_mgr_clean(struct upump_mgr *mgr)
  * @param pool_extra extra buffer space (see @ref upump_common_mgr_sizeof)
  * @param upump_real_start function of the real manager that starts a pump
  * @param upump_real_stop function of the real manager that stops a pump
+ * @param upump_real_restart function of the real manager that restarts a pump
  * @param upump_alloc_inner function to call to allocate a upump buffer
  * @param upump_free_inner function to call to release a upump buffer
  */
@@ -278,6 +294,7 @@ void upump_common_mgr_init(struct upump_mgr *mgr,
                            uint16_t upump_blocker_pool_depth, void *pool_extra,
                            void (*upump_real_start)(struct upump *, bool),
                            void (*upump_real_stop)(struct upump *, bool),
+                           void (*upump_real_restart)(struct upump *, bool),
                            void *(*upump_alloc_inner)(struct upool *),
                            void (*upump_free_inner)(struct upool *, void *))
 {
@@ -287,6 +304,7 @@ void upump_common_mgr_init(struct upump_mgr *mgr,
     struct upump_common_mgr *common_mgr = upump_common_mgr_from_upump_mgr(mgr);
     common_mgr->upump_real_start = upump_real_start;
     common_mgr->upump_real_stop = upump_real_stop;
+    common_mgr->upump_real_restart = upump_real_restart;
 
     upool_init(&common_mgr->upump_pool, mgr->refcount, upump_pool_depth,
                pool_extra, upump_alloc_inner, upump_free_inner);

--- a/lib/upump-ecore/upump_ecore.c
+++ b/lib/upump-ecore/upump_ecore.c
@@ -247,6 +247,26 @@ static void upump_ecore_real_start(struct upump *upump, bool status)
     }
 }
 
+/** @This restarts a pump.
+ *
+ * @param upump description structure of the pump
+ * @param status blocking status of the pump
+ */
+static void upump_ecore_real_restart(struct upump *upump, bool status)
+{
+    struct upump_ecore *upump_ecore = upump_ecore_from_upump(upump);
+    struct upump_ecore_mgr *ecore_mgr =
+        upump_ecore_mgr_from_upump_mgr(upump->mgr);
+
+    switch (upump_ecore->event) {
+        case UPUMP_TYPE_TIMER:
+            ecore_timer_reset(upump_ecore->timer);
+            break;
+        default:
+            break;
+    }
+}
+
 /** @This stops a pump.
  *
  * @param upump description structure of the pump
@@ -336,6 +356,9 @@ static int upump_ecore_control(struct upump *upump, int command, va_list args)
     switch (command) {
         case UPUMP_START:
             upump_common_start(upump);
+            return UBASE_ERR_NONE;
+        case UPUMP_RESTART:
+            upump_common_restart(upump);
             return UBASE_ERR_NONE;
         case UPUMP_STOP:
             upump_common_stop(upump);
@@ -465,6 +488,7 @@ struct upump_mgr *upump_ecore_mgr_alloc(uint16_t upump_pool_depth,
     upump_common_mgr_init(mgr, upump_pool_depth, upump_blocker_pool_depth,
                           ecore_mgr->upool_extra,
                           upump_ecore_real_start, upump_ecore_real_stop,
+                          upump_ecore_real_restart,
                           upump_ecore_alloc_inner, upump_ecore_free_inner);
     return mgr;
 }


### PR DESCRIPTION
Add upump_restart for timer pumps to reset the timeout.