### PR TITLE
fec: forward RTCP to next pipe

### DIFF
--- a/lib/upipe-ts/upipe_rtp_fec.c
+++ b/lib/upipe-ts/upipe_rtp_fec.c
@@ -794,9 +794,9 @@ static void upipe_rtp_fec_sub_input(struct upipe *upipe, struct uref *uref,
     bool marker = rtp_check_marker(rtp_header);
     uint8_t type = rtp_get_type(rtp_header);
     if (type >= 72 && type <= 95 && marker) {
-        upipe_warn_va(upipe, "Payload type %d is probably RTCP, dropping",
+        upipe_warn_va(upipe, "Payload type %d is probably RTCP, forwarding",
             type + 128);
-        uref_free(uref);
+        upipe_rtp_fec_output(upipe_rtp_fec_to_upipe(upipe_rtp_fec), uref, NULL);
         return;
     }
 


### PR DESCRIPTION
We need the RTCP packets if next pipe is doing arq
We just avoid doing FEC on this stream

Note that this commit is not enough, when doing ARQ we also need to pass through the retransmits,
which have a different payload type.

Copy/pasting IRC:

16:40 < funman> we have 5 streams
16:41 < funman> #1 main rtp (PT 33 since it's mpeg-ts)
16:41 < funman> #2 & 3 : row / column rtp, on 2 other ports
16:41 < funman> #4 RTCP (see above patch)
16:41 < funman> #5 retransmits, using PT 97
16:42 < funman> so fec needs to let RTCP (detectable) and retransmits (not detectable without an SDP) go through
16:43 < funman> not sure where else we do this but we could count packets with a different PT and reset if e.g. >5
16:43 < funman> so once we see PT 33, let everything else go through
16:43 < funman> and if we get 5 consecutive rtp packets with another PT we issue a discontinuity and start using that one
16:55 < funman> some fec but no nack except that one at the start