### PR TITLE
upipe-x265: work around x265.h undef warning

### DIFF
--- a/lib/upipe-x265/upipe_x265.c
+++ b/lib/upipe-x265/upipe_x265.c
@@ -68,6 +68,11 @@
 #include <stdio.h>
 #include <ctype.h>
 
+/* fix undef warning in x265.h */
+#ifndef ENABLE_LIBVMAF
+# define ENABLE_LIBVMAF 0
+#endif
+
 #include <x265.h>
 #include <bitstream/itu/h265.h>
 


### PR DESCRIPTION
Since x265 version 2.8:

x265.h:1880:5: error: 'ENABLE_LIBVMAF' is not defined, evaluates
to 0 [-Werror,-Wundef]