### PR TITLE
fec: check payload type

### DIFF
--- a/examples/fec.c
+++ b/examples/fec.c
@@ -66,13 +66,16 @@ static int set_uri(struct upipe *upipe, const char *base, uint16_t port)
 
 int main(int argc, char **argv)
 {
-    if (argc != 3) {
-        fprintf(stderr, "Usage: %s <input> <output>\n", argv[0]);
+    if (argc != 3 && argc != 4) {
+        fprintf(stderr, "Usage: %s <input> <output> [payload type]\n", argv[0]);
         return 1;
     }
 
     const char  *input = argv[1];
     const char *output = argv[2];
+    unsigned pt = 33; // MPEG-TS
+    if (argc == 4)
+        pt = atoi(argv[3]);
 
     /* upump manager */
     struct upump_mgr *main_upump_mgr = upump_ev_mgr_alloc_default(UPUMP_POOL,
@@ -142,6 +145,7 @@ int main(int argc, char **argv)
             uprobe_pfx_alloc(uprobe_use(uprobe_main), loglevel, "rtp_col_fec"),
             uprobe_pfx_alloc(uprobe_use(uprobe_main), loglevel, "rtp_row_fec"));
     assert(rtp_fec);
+    upipe_rtp_fec_set_pt(rtp_fec, pt);
     upipe_mgr_release(upipe_rtp_fec_mgr);
 
     upipe_attach_uclock(rtp_fec);

--- a/include/upipe-ts/upipe_rtp_fec.h
+++ b/include/upipe-ts/upipe_rtp_fec.h
@@ -32,6 +32,8 @@ enum rtp_fec_command {
     UPIPE_RTP_FEC_GET_ROWS,
     /** returns the number of columns (uint64_t *) */
     UPIPE_RTP_FEC_GET_COLUMNS,
+    /** sets expected payload type (unsigned) */
+    UPIPE_RTP_FEC_SET_PT,
 };
 
 static inline int upipe_rtp_fec_get_rows(struct upipe *upipe,
@@ -102,6 +104,18 @@ static inline int upipe_rtp_fec_get_row_sub(struct upipe *upipe,
 {
     return upipe_control(upipe, UPIPE_RTP_FEC_GET_ROW_SUB,
                          UPIPE_RTP_FEC_SIGNATURE, upipe_p);
+}
+
+/** @This sets the expected payload type
+ *
+ * @param upipe description structure of the super pipe
+ * @param pt expected payload type
+ * @return an error code
+ */
+static inline int upipe_rtp_fec_set_pt(struct upipe *upipe, unsigned pt)
+{
+    return upipe_control(upipe, UPIPE_RTP_FEC_SET_PT,
+                         UPIPE_RTP_FEC_SIGNATURE, pt);
 }
 
 /** @This returns the management structure for rtp_fec pipes.

--- a/lib/upipe-ts/upipe_rtp_fec.c
+++ b/lib/upipe-ts/upipe_rtp_fec.c
@@ -106,6 +106,9 @@ struct upipe_rtp_fec {
     } recent[2 * FEC_MAX * FEC_MAX];
     uint64_t latency;
 
+    /** detected payload type */
+    uint8_t pt;
+
     /** main subpipe **/
     struct upipe main_subpipe;
     /** col subpipe */
@@ -826,20 +829,18 @@ static void upipe_rtp_fec_sub_input(struct upipe *upipe, struct uref *uref,
         return;
     }
 
-    bool marker = rtp_check_marker(rtp_header);
-    uint8_t type = rtp_get_type(rtp_header);
-    if (type >= 72 && type <= 95 && marker) {
-        upipe_warn_va(upipe, "Payload type %d is probably RTCP, forwarding",
-            type + 128);
-        upipe_rtp_fec_output(upipe_rtp_fec_to_upipe(upipe_rtp_fec), uref, NULL);
-        return;
-    }
-
     uref->priv = rtp_get_seqnum(rtp_header);
     uref_block_peek_unmap(uref, 0, rtp_buffer, rtp_header);
 
     if (upipe != upipe_rtp_fec_to_main_subpipe(upipe_rtp_fec)) {
         upipe_rtp_fec_colrow_input(upipe, uref);
+        return;
+    }
+
+    uint8_t pt = rtp_get_type(rtp_header);
+    if (upipe_rtp_fec->pt != pt) {
+        upipe_dbg_va(upipe, "Forwarding payload type %u", pt);
+        upipe_rtp_fec_output(upipe_rtp_fec_to_upipe(upipe_rtp_fec), uref, NULL);
         return;
     }
 
@@ -954,6 +955,7 @@ static struct upipe *_upipe_rtp_fec_alloc(struct upipe_mgr *mgr,
     upipe_rtp_fec->last_send_seqnum = UINT32_MAX;
     upipe_rtp_fec->cur_matrix_snbase = UINT32_MAX;
     upipe_rtp_fec->cur_row_fec_snbase = UINT32_MAX;
+    upipe_rtp_fec->pt = UINT8_MAX;
 
     upipe_rtp_fec->lost = 0;
     upipe_rtp_fec->prev_date_sys = UINT64_MAX;
@@ -1071,6 +1073,11 @@ static int upipe_rtp_fec_control(struct upipe *upipe, int command, va_list args)
         UBASE_SIGNATURE_CHECK(args, UPIPE_RTP_FEC_SIGNATURE)
         uint64_t *columns = va_arg(args, uint64_t*);
         *columns = upipe_rtp_fec->cols;
+        return UBASE_ERR_NONE;
+    }
+    case UPIPE_RTP_FEC_SET_PT: {
+        UBASE_SIGNATURE_CHECK(args, UPIPE_RTP_FEC_SIGNATURE)
+        upipe_rtp_fec->pt = va_arg(args, unsigned);
         return UBASE_ERR_NONE;
     }
     default:


### PR DESCRIPTION
If a packet has a payload type different from the first packet,
forward it to the next pipe immediately.
This lets us include not only RTCP but also retransmits which are
multiplexed together with the original RTP stream