### PR TITLE
zoneplate: increase pattern complexity and comment

### DIFF
--- a/lib/upipe-filters/zoneplate/videotestsrc.c
+++ b/lib/upipe-filters/zoneplate/videotestsrc.c
@@ -26,8 +26,8 @@
 #define V_POINTER_KX      0 /* Zoneplate 1st order x phase, for generating constant horizontal frequencies */
 #define V_POINTER_KY      0 /* Zoneplate 1st order y phase, for generating contant vertical frequencies */
 #define V_POINTER_KT      1 /* Zoneplate 1st order t phase, for generating phase rotation as a function of time */
-#define V_POINTER_KXT     0 /* Zoneplate x*t product phase, normalised to kxy/256 cycles per vertical pixel at width/2 from origin */
-#define V_POINTER_KYT     0 /* Zoneplate y*t product phase */
+#define V_POINTER_KXT     2 /* Zoneplate x*t product phase, normalised to kxy/256 cycles per vertical pixel at width/2 from origin */
+#define V_POINTER_KYT     (-3) /* Zoneplate y*t product phase */
 #define V_POINTER_KXY     0 /* Zoneplate x*y product phase */
 #define V_POINTER_KX2     128 /* Zoneplate 2nd order x phase, normalised to kx2/256 cycles per horizontal pixel at width/2 from origin */
 #define V_POINTER_KY2     128 /* Zoneplate 2nd order y phase, normailsed to ky2/256 cycles per vertical pixel at height/2 from origin */

--- a/lib/upipe-filters/zoneplate/videotestsrc.c
+++ b/lib/upipe-filters/zoneplate/videotestsrc.c
@@ -29,8 +29,8 @@
 #define V_POINTER_KXT     0
 #define V_POINTER_KYT     0
 #define V_POINTER_KXY     0
-#define V_POINTER_KX2     20
-#define V_POINTER_KY2     20
+#define V_POINTER_KX2     128
+#define V_POINTER_KY2     128
 #define V_POINTER_KT2     0
 #define V_POINTER_XOFFSET 0
 #define V_POINTER_YOFFSET 0

--- a/lib/upipe-filters/zoneplate/videotestsrc.c
+++ b/lib/upipe-filters/zoneplate/videotestsrc.c
@@ -93,6 +93,9 @@ gst_video_test_src_zoneplate_8bit (uint8_t *data,
   int scale_kxy = 0xffff / (w / 2);
   int scale_kx2 = 0xffff / w;
 
+  const int KX2 = (h > w) ? V_POINTER_KX2 * w / h : V_POINTER_KX2;
+  const int KY2 = (w > h) ? V_POINTER_KY2 * h / w : V_POINTER_KY2;
+
   /* Zoneplate equation:
    *
    * phase = k0 + kx*x + ky*y + kt*t
@@ -142,7 +145,7 @@ gst_video_test_src_zoneplate_8bit (uint8_t *data,
     accum_kyt += V_POINTER_KYT * t;
     delta_kxy = V_POINTER_KXY * y * scale_kxy;
     accum_kxy = delta_kxy * xreset;
-    ky2 = (V_POINTER_KY2 * y * y) / h;
+    ky2 = (KY2 * y * y) / h;
     for (i = 0, x = xreset; i < w; i++, x++) {
 
       /* zero order */
@@ -166,7 +169,7 @@ gst_video_test_src_zoneplate_8bit (uint8_t *data,
       /*second order */
       /*normalise x/y terms to rate of change of phase at the picture edge */
       /*phase = phase + ((v->kx2 * x * x)/w) + ((v->ky2 * y * y)/h) + ((v->kt2 * t * t)>>1); */
-      phase = phase + ((V_POINTER_KX2 * x * x * scale_kx2) >> 16) + ky2 + (kt2 >> 1);
+      phase = phase + ((KX2 * x * x * scale_kx2) >> 16) + ky2 + (kt2 >> 1);
 
       data[j*stride + i] = sine_table[phase & 0xff];
     }
@@ -197,6 +200,9 @@ gst_video_test_src_zoneplate_10bit (uint16_t *data,
   int scale_kxy = 0xffff / (w / 2);
   int scale_kx2 = 0xffff / w;
 
+  const int KX2 = (h > w) ? V_POINTER_KX2 * w / h : V_POINTER_KX2;
+  const int KY2 = (w > h) ? V_POINTER_KY2 * h / w : V_POINTER_KY2;
+
   stride /= 2;
 
   accum_ky = 0;
@@ -210,7 +216,7 @@ gst_video_test_src_zoneplate_10bit (uint16_t *data,
     accum_kyt += V_POINTER_KYT * t;
     delta_kxy = V_POINTER_KXY * y * scale_kxy;
     accum_kxy = delta_kxy * xreset;
-    ky2 = (V_POINTER_KY2 * y * y) / h;
+    ky2 = (KY2 * y * y) / h;
     for (i = 0, x = xreset; i < w; i++, x++) {
 
       /* zero order */
@@ -229,7 +235,7 @@ gst_video_test_src_zoneplate_10bit (uint16_t *data,
 
       /*second order */
       /*normalise x/y terms to rate of change of phase at the picture edge */
-      phase = phase + ((V_POINTER_KX2 * x * x * scale_kx2) >> 16) + ky2 + (kt2 >> 1);
+      phase = phase + ((KX2 * x * x * scale_kx2) >> 16) + ky2 + (kt2 >> 1);
 
       data[j*stride + i] = sine_table[phase & 0xff] << 2;
     }

--- a/lib/upipe-filters/zoneplate/videotestsrc.c
+++ b/lib/upipe-filters/zoneplate/videotestsrc.c
@@ -22,18 +22,18 @@
 
 #include "videotestsrc.h"
 
-#define V_POINTER_K0      0
-#define V_POINTER_KX      0
-#define V_POINTER_KY      0
-#define V_POINTER_KT      1
-#define V_POINTER_KXT     0
-#define V_POINTER_KYT     0
-#define V_POINTER_KXY     0
-#define V_POINTER_KX2     128
-#define V_POINTER_KY2     128
-#define V_POINTER_KT2     0
-#define V_POINTER_XOFFSET 0
-#define V_POINTER_YOFFSET 0
+#define V_POINTER_K0      0 /* Zoneplate zero order phase, for generating plain fields or phase offsets */
+#define V_POINTER_KX      0 /* Zoneplate 1st order x phase, for generating constant horizontal frequencies */
+#define V_POINTER_KY      0 /* Zoneplate 1st order y phase, for generating contant vertical frequencies */
+#define V_POINTER_KT      1 /* Zoneplate 1st order t phase, for generating phase rotation as a function of time */
+#define V_POINTER_KXT     0 /* Zoneplate x*t product phase, normalised to kxy/256 cycles per vertical pixel at width/2 from origin */
+#define V_POINTER_KYT     0 /* Zoneplate y*t product phase */
+#define V_POINTER_KXY     0 /* Zoneplate x*y product phase */
+#define V_POINTER_KX2     128 /* Zoneplate 2nd order x phase, normalised to kx2/256 cycles per horizontal pixel at width/2 from origin */
+#define V_POINTER_KY2     128 /* Zoneplate 2nd order y phase, normailsed to ky2/256 cycles per vertical pixel at height/2 from origin */
+#define V_POINTER_KT2     0 /* Zoneplate 2nd order t phase, t*t/256 cycles per picture */
+#define V_POINTER_XOFFSET 0 /* Zoneplate 2nd order products x offset */
+#define V_POINTER_YOFFSET 0 /* Zoneplate 2nd order products y offset */
 
 static const uint8_t sine_table[256] = {
   128, 131, 134, 137, 140, 143, 146, 149,


### PR DESCRIPTION
A couple of changes to possibly make the pattern harder to encode.

The first "zooms out" on the pattern to show higher frequencies.  The second is almost purely cosmetic and will adjust the pattern to keep it circular (assuming pixel aspect ratio of 1).  The third copies the descriptions of the config options from Gstreamer so that a user has that reference to hand should they wish to change it.  The fourth makes that pattern "move" left and downward, at least that is how the human eye sees it.

@kierank wanted the pattern made harder to stress encoders.