### PR TITLE
upipe-netmap: add BITSTREAM_CFLAGS

### DIFF
--- a/lib/upipe-netmap/Makefile.am
+++ b/lib/upipe-netmap/Makefile.am
@@ -2,7 +2,7 @@ lib_LTLIBRARIES = libupipe_netmap.la
 
 libupipe_netmap_la_SOURCES = upipe_netmap_source.c \
     $(NULL)
-libupipe_netmap_la_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
+libupipe_netmap_la_CPPFLAGS = $(BITSTREAM_CFLAGS) -I$(top_builddir)/include -I$(top_srcdir)/include
 libupipe_netmap_la_LIBADD = $(top_builddir)/lib/upipe/libupipe.la
 libupipe_netmap_la_LDFLAGS = -no-undefined
 


### PR DESCRIPTION
As title says.  Now that I think about it, is there a NETMAP_CFLAGS that should be added too?