### PR TITLE
upipe-x265: work around x265.h undef warnings

### DIFF
--- a/lib/upipe-x265/upipe_x265.c
+++ b/lib/upipe-x265/upipe_x265.c
@@ -68,9 +68,15 @@
 #include <stdio.h>
 #include <ctype.h>
 
-/* fix undef warning in x265.h */
+/* fix undef warnings in x265.h */
 #ifndef ENABLE_LIBVMAF
 # define ENABLE_LIBVMAF 0
+#endif
+#ifndef _MSC_VER
+# define _MSC_VER 0
+#endif
+#ifndef X265_DEPTH
+# define X265_DEPTH 0
 #endif
 
 #include <x265.h>


### PR DESCRIPTION
Since x265 version 2.9:

x265.h:34:5: error: '_MSC_VER' is not defined, evaluates to 0
x265.h:175:5: error: 'X265_DEPTH' is not defined, evaluates to 0