### PR TITLE
upipe-av: add avfsink mgr command for checking flow defs

### DIFF
--- a/include/upipe/upipe.h
+++ b/include/upipe/upipe.h
@@ -187,6 +187,8 @@ UBASE_FROM_TO(upipe, uchain, uchain, uchain)
 enum upipe_mgr_command {
     /** release all buffers kept in pools (void) */
     UPIPE_MGR_VACUUM,
+    /** check that a specific flow def is supported (struct uref *) */
+    UPIPE_MGR_CHECK_FLOW_DEF,
 
     /** non-standard manager commands implemented by a module type can start
      * from there (first arg = signature) */
@@ -292,6 +294,18 @@ static inline int upipe_mgr_control(struct upipe_mgr *mgr, int command, ...)
 static inline int upipe_mgr_vacuum(struct upipe_mgr *mgr)
 {
     return upipe_mgr_control(mgr, UPIPE_MGR_VACUUM);
+}
+
+/** @This checks that a specific flow def is supported.
+ *
+ * @param mgr pointer to upipe manager
+ * @param flow_def flow def to check
+ * @return an error code
+ */
+static inline int upipe_mgr_check_flow_def(struct upipe_mgr *mgr,
+                                           struct uref *flow_def)
+{
+    return upipe_mgr_control(mgr, UPIPE_MGR_CHECK_FLOW_DEF, flow_def);
 }
 
 /** @This return the corresponding error string.

--- a/luajit/Makefile.in
+++ b/luajit/Makefile.in
@@ -201,6 +201,7 @@ libupipe.lua: $(srcdir)/gen-ffi-cdef.pl $(srcdir)/libc.defs upipe.debug_info upi
 	  --write-defs upipe.defs \
 	  --enum ubase_err \
 	  --enum upipe_command \
+	  --enum upipe_mgr_command \
 	  --enum uref_date_type \
 	  --enum uprobe_event \
 	  --enum 'urequest_*' \


### PR DESCRIPTION
Allocating an avfsink subpipe adds a stream to the avformat context,
which cannot be removed afterwards, so we need to be able to check that
a given flow def is supported before allocating the subpipe.