### PR TITLE
rist_rx: restart RTCP socket in case of error

### DIFF
--- a/examples/rist_rx.c
+++ b/examples/rist_rx.c
@@ -129,6 +129,7 @@ static void gather_stats(struct upipe *upipe, struct uref *uref)
 static int catch_udp(struct uprobe *uprobe, struct upipe *upipe,
                  int event, va_list args)
 {
+    const char *uri;
     switch (event) {
     case UPROBE_UDPSRC_NEW_PEER: {
         int sig = va_arg(args, int);
@@ -174,6 +175,10 @@ static int catch_udp(struct uprobe *uprobe, struct upipe *upipe,
         ubase_assert(upipe_udpsink_set_peer(rtcp_sink,
                     (const struct sockaddr*)&addr, addr_len));
         upipe_release(rtcp_sink);
+        return UBASE_ERR_NONE;
+    case UPROBE_SOURCE_END:
+        /* This control can not fail, and will trigger restart of upump */
+        upipe_get_uri(upipe, &uri);
         return UBASE_ERR_NONE;
     default:
         return uprobe_throw_next(uprobe, upipe, event, args);


### PR DESCRIPTION
We already do the same thing in rist_tx
This avoid killing the entire RTCP channel in case of spurious error