### PR TITLE
upipe_udp: fix upump fd close race condition

### DIFF
--- a/lib/upipe-modules/upipe_udp_sink.c
+++ b/lib/upipe-modules/upipe_udp_sink.c
@@ -565,6 +565,10 @@ static int upipe_udpsink_control(struct upipe *upipe, int command, va_list args)
 static void upipe_udpsink_free(struct upipe *upipe)
 {
     struct upipe_udpsink *upipe_udpsink = upipe_udpsink_from_upipe(upipe);
+
+    if (upipe_udpsink->upump != NULL)
+        upump_stop(upipe_udpsink->upump);
+
     if (likely(upipe_udpsink->fd != -1)) {
         if (likely(upipe_udpsink->uri != NULL))
             upipe_notice_va(upipe, "closing socket %s", upipe_udpsink->uri);

--- a/lib/upipe-modules/upipe_udp_source.c
+++ b/lib/upipe-modules/upipe_udp_source.c
@@ -444,6 +444,9 @@ static void upipe_udpsrc_free(struct upipe *upipe)
 {
     struct upipe_udpsrc *upipe_udpsrc = upipe_udpsrc_from_upipe(upipe);
 
+    if (upipe_udpsrc->upump != NULL)
+        upump_stop(upipe_udpsrc->upump);
+
     if (likely(upipe_udpsrc->fd != -1)) {
         if (likely(upipe_udpsrc->uri != NULL))
             upipe_notice_va(upipe, "closing udp socket %s", upipe_udpsrc->uri);


### PR DESCRIPTION
fds must be removed from the epoll set before closing, otherwise a race
condition can trigger when a new fd is created with the same value as
the closed one.