### PR TITLE
upipe-modules: prevent an infinite loop in voidsrc

### DIFF
--- a/lib/upipe-modules/upipe_void_source.c
+++ b/lib/upipe-modules/upipe_void_source.c
@@ -184,7 +184,8 @@ static void upipe_voidsrc_worker(struct upump *upump)
         uref_clock_set_duration(uref, upipe_voidsrc->interval);
         uref_clock_set_pts_sys(uref, upipe_voidsrc->pts);
         uref_clock_set_pts_prog(uref, upipe_voidsrc->pts);
-        upipe_voidsrc->pts += upipe_voidsrc->interval;
+        if (upipe_voidsrc->pts != UINT64_MAX)
+            upipe_voidsrc->pts += upipe_voidsrc->interval;
 
         upipe_voidsrc_output(upipe, uref, &upipe_voidsrc->timer);
 

--- a/lib/upipe-modules/upipe_void_source.c
+++ b/lib/upipe-modules/upipe_void_source.c
@@ -194,7 +194,7 @@ static void upipe_voidsrc_worker(struct upump *upump)
             break;
     }
 
-    uint64_t wait = 0;
+    uint64_t wait = upipe_voidsrc->interval;
     if (now != UINT64_MAX)
         wait = upipe_voidsrc->pts - now;
 

--- a/lib/upipe-modules/upipe_void_source.c
+++ b/lib/upipe-modules/upipe_void_source.c
@@ -167,12 +167,12 @@ static void upipe_voidsrc_worker(struct upump *upump)
 {
     struct upipe *upipe = upump_get_opaque(upump, struct upipe *);
     struct upipe_voidsrc *upipe_voidsrc = upipe_voidsrc_from_upipe(upipe);
-    uint64_t now;
 
+    uint64_t now = uclock_now(upipe_voidsrc->uclock);
     if (upipe_voidsrc->pts == UINT64_MAX)
-        upipe_voidsrc->pts = uclock_now(upipe_voidsrc->uclock);
+        upipe_voidsrc->pts = now;
 
-    for (now = uclock_now(upipe_voidsrc->uclock);
+    for (/* nothing */;
          !upipe_single(upipe) && upipe_voidsrc->pts <= now;
          now = uclock_now(upipe_voidsrc->uclock)) {
         struct uref *uref = uref_alloc(upipe_voidsrc->uref_mgr);


### PR DESCRIPTION
This change addresses the issue I was experiencing but I am not sure how "correct" it is.  Please comment if you think there's a better way to handle this.