### PR TITLE
upipe-modules: make upipe_sync catch UINT64_MAX values from uclock_now

### DIFF
--- a/lib/upipe-modules/upipe_sync.c
+++ b/lib/upipe-modules/upipe_sync.c
@@ -799,11 +799,18 @@ static void cb(struct upump *upump)
 
     /* schedule next pic */
     now = uclock_now(upipe_sync->uclock);
-    while (now > upipe_sync->pts) {
+    while (now != UINT64_MAX && now > upipe_sync->pts) {
         upipe_sync->pts += upipe_sync->ticks_per_frame;
         upipe_err_va(upipe, "skipping a beat");
     }
-    upipe_sync_wait_upump(upipe, upipe_sync->pts - now, cb);
+
+    uint64_t wait;
+    if (now == UINT64_MAX)
+        wait = upipe_sync->ticks_per_frame;
+    else
+        wait = upipe_sync->pts - now;
+
+    upipe_sync_wait_upump(upipe, wait, cb);
 }
 
 /** @internal @This receives data.
@@ -886,7 +893,7 @@ static void upipe_sync_input(struct upipe *upipe, struct uref *uref,
     uint64_t now = uclock_now(upipe_sync->uclock);
 
     /* reject late pics */
-    if (now > pts) {
+    if (now != UINT64_MAX && now > pts) {
         uint64_t cr = 0;
         uref_clock_get_cr_sys(uref, &cr);
         upipe_err_va(upipe, "%s() picture too late by %" PRIu64 "ms, drop pic, recept %" PRIu64 "",
@@ -910,8 +917,14 @@ static void upipe_sync_input(struct upipe *upipe, struct uref *uref,
         return;
 
     /* start timer */
+    uint64_t wait;
+    if (now == UINT64_MAX)
+        wait = upipe_sync->ticks_per_frame;
+    else
+        wait = pts - now;
+
     upipe_sync->pts = pts;
-    upipe_sync_wait_upump(upipe_sync_to_upipe(upipe_sync), pts - now, cb);
+    upipe_sync_wait_upump(upipe_sync_to_upipe(upipe_sync), wait, cb);
 }
 
 /** @internal @This allocates a sync pipe.


### PR DESCRIPTION
Do not drop frames when that happens.  Do not try to wait using that
time.  Do not try to adjust PTS using that time.

Perhaps there is a better way to address this.  However this change has let me get output when using my clock and sink.

I have a cosmetic question.  What is Upipe's opinion on conditional ternary operators?  The if-else expressions could be shortened to `(now == UINT64_MAX) ? ticks_per_frame : pts - now`