### PR TITLE
upipe-modules: Add audio_merge pipe

### DIFF
--- a/include/upipe-modules/Makefile.am
+++ b/include/upipe-modules/Makefile.am
@@ -86,4 +86,5 @@ myinclude_HEADERS = \
 	upipe_row_split.h \
 	upipe_separate_fields.h \
 	upipe_row_join.h \
+	upipe_audio_merge.h \
 	$(NULL)

--- a/include/upipe-modules/upipe_audio_merge.h
+++ b/include/upipe-modules/upipe_audio_merge.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 - 2019 Open Broadcast Systems Ltd.
+ *
+ * Authors: Kieran Kunhya
+ *          Sam Willcocks
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ */
+
+/** @file
+ * @short Upipe module merging audio from several input subpipes into a single buffer
+ *
+ * This module accepts audio from input subpipes and outputs a single pipe of n-channel/plane audio.
+ * Each input must be sent urefs at the same rate, as the pipe will not output until every input channel
+ * has received a uref. The pipe makes no attempt to retime or resample.
+ * Input audio must have the same format, save for the number of channels/planes.
+ */
+
+#ifndef _UPIPE_MODULES_UPIPE_AUDIO_MERGE_H_
+/** @hidden */
+#define _UPIPE_MODULES_UPIPE_AUDIO_MERGE_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <upipe/upipe.h>
+#include <upipe/upump.h>
+#include <upipe/uref_attr.h>
+
+#define UPIPE_AUDIO_MERGE_SIGNATURE UBASE_FOURCC('a','m','g','l')
+#define UPIPE_AUDIO_MERGE_INPUT_SIGNATURE UBASE_FOURCC('a','m','g','i')
+
+/** @This returns the management structure for all audio_merge pipes.
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_audio_merge_mgr_alloc(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/upipe/ubase.h
+++ b/include/upipe/ubase.h
@@ -238,7 +238,7 @@ do {                                                                        \
 } while (0);
 
 /** @This runs the given function and returns if the error code is not
- * UBASE_ERR_UNHANDLER.
+ * UBASE_ERR_UNHANDLED.
  *
  * @param command command whose return code is to be checked
  */

--- a/lib/upipe-modules/Makefile.am
+++ b/lib/upipe-modules/Makefile.am
@@ -79,6 +79,7 @@ libupipe_modules_la_SOURCES = \
 	upipe_row_split.c \
 	upipe_separate_fields.c \
 	upipe_row_join.c \
+	upipe_audio_merge.c \
 	$(NULL)
 
 if HAVE_WRITEV

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -1,0 +1,638 @@
+/*
+ * Copyright (C) 2015 - 2019 Open Broadcast Systems Ltd.
+ *
+ * Authors: Kieran Kunhya
+ *          Sam Willcocks
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ */
+
+/** @file
+ * @short Upipe module merging audio from several input subpipes into a single buffer
+ *
+ * This module accepts audio from input subpipes and outputs a single pipe of n-channel/plane audio.
+ * Each input must be sent urefs at the same rate, as the pipe will not output until every input channel
+ * has received a uref. The pipe makes no attempt to retime or resample.
+ * Input audio must have the same format, save for the number of channels/planes.
+ */
+
+#include <upipe/ubase.h>
+#include <upipe/ulist.h>
+#include <upipe/uprobe.h>
+#include <upipe/uref.h>
+#include <upipe/uref_dump.h>
+#include <upipe/ubuf.h>
+#include <upipe/upipe.h>
+#include <upipe/uref_sound.h>
+#include <upipe/uref_sound_flow.h>
+#include <upipe/upipe_helper_upipe.h>
+#include <upipe/upipe_helper_urefcount.h>
+#include <upipe/upipe_helper_void.h>
+#include <upipe/upipe_helper_flow.h>
+#include <upipe/upipe_helper_input.h>
+#include <upipe/upipe_helper_output.h>
+#include <upipe/upipe_helper_subpipe.h>
+#include <upipe/upipe_helper_ubuf_mgr.h>
+#include <upipe/upipe_helper_upump_mgr.h>
+#include <upipe/upipe_helper_upump.h>
+#include <upipe/umem.h>
+#include <upipe/ubuf.h>
+#include <upipe/ubuf_sound.h>
+#include <upipe/ubuf_sound_mem.h>
+#include <upipe-modules/upipe_audio_merge.h>
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <assert.h>
+
+#define UBUF_POOL_DEPTH 2
+
+#ifndef MIN
+# define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
+# define MAX(a,b) ((a) > (b) ? (a) : (b))
+#endif
+
+/** @hidden */
+static int upipe_audio_merge_check(struct upipe *upipe, struct uref *flow_format);
+
+/** @internal @This is the private context of an audio_merge pipe. */
+struct upipe_audio_merge {
+    /** real refcount management structure */
+    struct urefcount urefcount_real;
+    /** refcount management structure exported to the public structure */
+    struct urefcount urefcount;
+
+    /** ubuf manager */
+    struct ubuf_mgr *ubuf_mgr;
+    /** flow format packet */
+    struct uref *flow_format;
+    /** ubuf manager request */
+    struct urequest ubuf_mgr_request;
+
+    /** list of input subpipes */
+    struct uchain inputs;
+
+    /** output pipe */
+    struct upipe *output;
+    /** flow_definition packet */
+    struct uref *flow_def;
+    /** output state */
+    enum upipe_helper_output_state output_state;
+    /** list of output requests */
+    struct uchain request_list;
+
+    /** flow def of the first input subpipe, used to check if the format
+     *  of subsequent subpipes match */
+    struct uref *sub_flow_def;
+
+    /** manager to create input subpipes */
+    struct upipe_mgr sub_mgr;
+
+    /** upump manager */
+    struct upump_mgr *upump_mgr;
+    /** watcher */
+    struct upump *upump;
+
+    /** channels **/
+    uint8_t channels;
+
+    /** public upipe structure */
+    struct upipe upipe;
+};
+
+UPIPE_HELPER_UPIPE(upipe_audio_merge, upipe, UPIPE_AUDIO_MERGE_SIGNATURE)
+UPIPE_HELPER_UREFCOUNT(upipe_audio_merge, urefcount, upipe_audio_merge_no_input)
+UPIPE_HELPER_OUTPUT(upipe_audio_merge, output, flow_def, output_state, request_list)
+UPIPE_HELPER_FLOW(upipe_audio_merge, "sound.")
+UPIPE_HELPER_UBUF_MGR(upipe_audio_merge, ubuf_mgr, flow_format,
+                      ubuf_mgr_request,
+                      upipe_audio_merge_check,
+                      upipe_audio_merge_register_output_request,
+                      upipe_audio_merge_unregister_output_request)
+
+UPIPE_HELPER_UPUMP_MGR(upipe_audio_merge, upump_mgr);
+UPIPE_HELPER_UPUMP(upipe_audio_merge, upump, upump_mgr);
+
+UBASE_FROM_TO(upipe_audio_merge, urefcount, urefcount_real, urefcount_real)
+
+/** @hidden */
+static void upipe_audio_merge_free(struct urefcount *urefcount_real);
+
+/** @internal @This is the private context of an output of an audio_merge
+ * pipe. */
+struct upipe_audio_merge_sub {
+    /** refcount management structure */
+    struct urefcount urefcount;
+    /** structure for double-linked lists */
+    struct uchain uchain;
+
+    /** current input flow definition packet */
+    struct uref *flow_def;
+
+    /** the single uref of incoming audio */
+    struct uref *uref;
+
+    /** public upipe structure */
+    struct upipe upipe;
+};
+
+UPIPE_HELPER_UPIPE(upipe_audio_merge_sub, upipe,
+                   UPIPE_AUDIO_MERGE_INPUT_SIGNATURE)
+UPIPE_HELPER_UREFCOUNT(upipe_audio_merge_sub, urefcount,
+                       upipe_audio_merge_sub_free)
+UPIPE_HELPER_VOID(upipe_audio_merge_sub)
+
+UPIPE_HELPER_SUBPIPE(upipe_audio_merge, upipe_audio_merge_sub, input,
+                     sub_mgr, inputs, uchain)
+
+/** @internal @Checks if two flow defs match, except for channel count
+ *
+ * @param one first uref
+ * @param two second uref
+ * @return true if flow defs match, false if not
+ */
+static bool upipe_audio_merge_match_flowdefs(struct uref *one, struct uref *two)
+{
+    return uref_sound_flow_cmp_rate(one, two) == 0
+                && uref_sound_flow_cmp_sample_size(one, two) == 0
+                && uref_sound_flow_cmp_samples(one, two) == 0
+                && uref_sound_flow_cmp_align(one, two) == 0;
+}
+
+static int upipe_audio_merge_sub_set_flow_def(struct upipe *upipe,
+                                              struct uref *flow_def)
+{
+    struct upipe_audio_merge *upipe_audio_merge =
+        upipe_audio_merge_from_sub_mgr(upipe->mgr);
+    struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+        upipe_audio_merge_sub_from_upipe(upipe);
+
+    if (flow_def == NULL)
+        return UBASE_ERR_INVALID;
+
+    /* reject interleaved audio */
+    uint8_t channels = 0, planes = 0;
+    UBASE_ERROR(upipe, uref_sound_flow_get_planes(flow_def, &planes));
+    UBASE_ERROR(upipe, uref_sound_flow_get_channels(flow_def, &channels));
+    if (planes != channels) {
+        upipe_err(upipe, "Interleaved audio not supported");
+        return UBASE_ERR_INVALID;
+    }
+    /* compare against stored flowdef (if we have one) and reject if formats don't match */
+    if (upipe_audio_merge->sub_flow_def
+            && !upipe_audio_merge_match_flowdefs(flow_def, upipe_audio_merge->sub_flow_def))
+    {
+        upipe_err(upipe, "Subpipe has non-matching audio format!");
+        return UBASE_ERR_INVALID;
+    }
+
+    /* .. and if we don't have one store this one */
+    if (!upipe_audio_merge->sub_flow_def)
+        upipe_audio_merge->sub_flow_def = uref_dup(flow_def);
+
+    /* store in the subpipe structure itself for later reference */
+    uref_free(upipe_audio_merge_sub->flow_def);
+    upipe_audio_merge_sub->flow_def = uref_dup(flow_def);
+
+    return UBASE_ERR_NONE;
+}
+
+/** @internal @This allocates an input subpipe of an audio_merge pipe.
+ *
+ * @param mgr common management structure
+ * @param uprobe structure used to raise events
+ * @param signature signature of the pipe allocator
+ * @param args optional arguments
+ * @return pointer to upipe or NULL in case of allocation error
+ */
+static struct upipe *upipe_audio_merge_sub_alloc(struct upipe_mgr *mgr,
+                                                 struct uprobe *uprobe,
+                                                 uint32_t signature, va_list args)
+{
+    struct upipe *upipe = upipe_audio_merge_sub_alloc_void(mgr,
+                            uprobe, signature, args);
+    if (unlikely(upipe == NULL)) {
+        return NULL;
+    }
+
+    struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+                            upipe_audio_merge_sub_from_upipe(upipe);
+
+    upipe_audio_merge_sub_init_urefcount(upipe);
+    upipe_audio_merge_sub_init_sub(upipe);
+    upipe_audio_merge_sub->uref = NULL;
+    upipe_audio_merge_sub->flow_def = NULL;
+    upipe_throw_ready(upipe);
+    return upipe;
+}
+
+/** @internal @This processes control commands on an input subpipe of an
+ *  audio_merge pipe.
+ *
+ * @param upipe description structure of the pipe
+ * @param command type of command to process
+ * @param args arguments of the command
+ * @return an error code
+ */
+static int upipe_audio_merge_sub_control(struct upipe *upipe,
+                                         int command, va_list args)
+{
+    UBASE_HANDLED_RETURN(upipe_audio_merge_sub_control_super(upipe, command, args));
+    switch (command) {
+        case UPIPE_REGISTER_REQUEST: {
+            struct urequest *request = va_arg(args, struct urequest *);
+            return upipe_throw_provide_request(upipe, request);
+        }
+        case UPIPE_UNREGISTER_REQUEST:
+            return UBASE_ERR_NONE;
+        case UPIPE_SUB_GET_SUPER: {
+            struct upipe **p = va_arg(args, struct upipe **);
+            return upipe_audio_merge_sub_get_super(upipe, p);
+        }
+        case UPIPE_SET_FLOW_DEF: {
+            struct uref *flow_def = va_arg(args, struct uref *);
+            return upipe_audio_merge_sub_set_flow_def(upipe, flow_def);
+        }
+
+        default:
+            return UBASE_ERR_UNHANDLED;
+    }
+}
+
+/** @internal @Copies data from the input urefs to an output buffer.
+ *
+ * @param upipe description structure of the pipe
+ * @param out_data the output buffer
+ */
+static void upipe_audio_merge_copy_to_output(struct upipe *upipe, float **out_data)
+{
+    int8_t out_channel_count = 0;
+    struct upipe_audio_merge *upipe_audio_merge = upipe_audio_merge_from_upipe(upipe);
+    struct uchain *uchain;
+    int i, j;
+
+    ulist_foreach (&upipe_audio_merge->inputs, uchain) {
+        struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+            upipe_audio_merge_sub_from_uchain(uchain);
+
+        uint8_t planes = 0;
+        UBASE_ERROR(upipe, uref_sound_flow_get_planes(upipe_audio_merge_sub->flow_def, &planes));
+
+        float *in_data[planes];
+        UBASE_ERROR(upipe, uref_sound_read_float(upipe_audio_merge_sub->uref, 0, -1, (const float**)in_data, planes));
+
+        uint64_t input_num_samples = 0;
+        UBASE_ERROR(upipe, uref_sound_flow_get_samples(upipe_audio_merge_sub->uref, &input_num_samples));
+
+        uint64_t output_num_samples = 0;
+        UBASE_ERROR(upipe, uref_sound_flow_get_samples(upipe_audio_merge->flow_def, &output_num_samples));
+
+        uint8_t output_channels = 0;
+        UBASE_ERROR(upipe, uref_sound_flow_get_channels(upipe_audio_merge->flow_def, &output_channels));
+
+        // If the samples of the input uref != our output sample size, throw an error and don't copy
+        if (unlikely(input_num_samples != output_num_samples))
+            upipe_err_va(upipe, "input samples (%"PRIu64") != output samples (%"PRIu64")!",
+                input_num_samples, output_num_samples);
+        // Todo: ensure #planes in uref matches the flowdef?
+        else {
+            for ( i = 0; i < planes; i++ ) {
+                /* Only copy up to the number of channels in the output flowdef,
+                and thus what we've allocated */
+                if ((out_channel_count + i) < output_channels) {
+                    for ( j = 0; j < input_num_samples; j++) {
+                        out_data[out_channel_count+i][j] = in_data[i][j];
+                    }
+                }
+            }
+        }
+        out_channel_count += planes;
+
+        uref_sound_unmap(upipe_audio_merge_sub->uref, 0, -1, planes);
+        uref_free(upipe_audio_merge_sub->uref);
+        upipe_audio_merge_sub->uref = NULL;
+    }
+}
+
+/** @internal @Output a uref, if possible
+ *
+ * @param upipe description structure of the pipe
+ * @param command type of command to process
+ * @param args arguments of the command
+ * @return an error code
+ */
+static void upipe_audio_merge_produce_output(struct upipe *upipe, struct upump **upump)
+{
+    struct upipe_audio_merge *upipe_audio_merge = upipe_audio_merge_from_upipe(upipe);
+    struct uchain *uchain;
+    struct uref *output_uref = NULL;
+    int i;
+    struct ubuf *ubuf;
+
+    if (unlikely(upipe_audio_merge->ubuf_mgr == NULL))
+        return;
+
+    /* interate through input subpipes, checking if they all have a uref available
+       and counting the number of channels */
+    ulist_foreach (&upipe_audio_merge->inputs, uchain) {
+        struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+            upipe_audio_merge_sub_from_uchain(uchain);
+
+        /* If any of the input subpipes does not have a flowdef/uref ready
+           we're not ready to output */
+        if (upipe_audio_merge_sub->uref == NULL || upipe_audio_merge_sub->flow_def == NULL)
+            return;
+    }
+
+    uint64_t input_channels = 0;
+    ulist_foreach (&upipe_audio_merge->inputs, uchain) {
+        struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+            upipe_audio_merge_sub_from_uchain(uchain);
+        /* if we haven't got one already, copy the uref to form the basis of our output uref */
+        if (output_uref == NULL)
+            output_uref = uref_dup(upipe_audio_merge_sub->uref);
+
+        uint8_t channels = 0;
+        UBASE_ERROR(upipe, uref_sound_flow_get_channels(upipe_audio_merge_sub->flow_def, &channels));
+        input_channels += channels;
+    }
+
+    if (unlikely(!output_uref))
+        return;
+
+    /* If total channels in input subpipes != channels in flow def throw an error */
+    uint8_t output_channels = 0;
+    UBASE_ERROR(upipe, uref_sound_flow_get_channels(upipe_audio_merge->flow_def, &output_channels));
+    if (input_channels != output_channels)
+        upipe_err_va(upipe, "total input channels (%"PRIu64") != output flow def (%d), some will be skipped or blanked!",
+            input_channels, output_channels);
+
+    uint64_t output_num_samples = 0;
+    UBASE_ERROR(upipe, uref_sound_flow_get_samples(upipe_audio_merge->flow_def, &output_num_samples));
+
+    float *out_data[output_channels];
+
+    /* Alloc and zero the output ubuf */
+    ubuf = ubuf_sound_alloc(upipe_audio_merge->ubuf_mgr, output_num_samples);
+    if (unlikely(ubuf == NULL)) {
+        upipe_throw_error(upipe, UBASE_ERR_ALLOC);
+        return;
+    }
+    UBASE_ERROR(upipe, ubuf_sound_write_float(ubuf, 0, -1, out_data, output_channels));
+    for ( i = 0; i < output_channels; i++ )
+        memset(out_data[i], 0, sizeof(float) * output_num_samples);
+
+    /* copy input data to output */
+    upipe_audio_merge_copy_to_output(upipe, out_data);
+
+    /* clean up and output */
+    ubuf_sound_unmap(ubuf, 0, -1, output_channels);
+    uref_sound_flow_set_samples(output_uref, output_num_samples);
+    uref_attach_ubuf(output_uref, ubuf);
+    upipe_audio_merge_output(upipe, output_uref, upump);
+}
+
+/** @internal @This handles input data.
+ *
+ * @param upipe description structure of the pipe
+ * @param uref uref structure
+ * @param upump_p reference to upump structure
+ */
+static void upipe_audio_merge_sub_input(struct upipe *upipe, struct uref *uref,
+                                        struct upump **upump_p)
+{
+    struct upipe_audio_merge *upipe_audio_merge =
+        upipe_audio_merge_from_sub_mgr(upipe->mgr);
+
+    struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+                              upipe_audio_merge_sub_from_upipe(upipe);
+
+    if (upipe_audio_merge_sub->uref != NULL) {
+        uref_free(upipe_audio_merge_sub->uref);
+        upipe_warn(upipe, "Got new uref before last one was output!");
+    }
+    upipe_audio_merge_sub->uref = uref;
+
+    // produce output, if we have all urefs
+    upipe_audio_merge_produce_output(upipe_audio_merge_to_upipe(upipe_audio_merge), upump_p);
+}
+
+/** @This frees a upipe.
+ *
+ * @param upipe description structure of the pipe
+ */
+static void upipe_audio_merge_sub_free(struct upipe *upipe)
+{
+    struct upipe_audio_merge_sub *upipe_audio_merge_sub =
+                              upipe_audio_merge_sub_from_upipe(upipe);
+
+    uref_free(upipe_audio_merge_sub->uref);
+    uref_free(upipe_audio_merge_sub->flow_def);
+
+    upipe_throw_dead(upipe);
+
+    upipe_audio_merge_sub_clean_sub(upipe);
+    upipe_audio_merge_sub_clean_urefcount(upipe);
+    upipe_audio_merge_sub_free_void(upipe);
+}
+
+/** @internal @This initializes the output manager for an audio_merge sub pipe.
+ *
+ * @param upipe description structure of the pipe
+ */
+static void upipe_audio_merge_init_sub_mgr(struct upipe *upipe)
+{
+    struct upipe_audio_merge *upipe_audio_merge =
+                              upipe_audio_merge_from_upipe(upipe);
+    struct upipe_mgr *sub_mgr = &upipe_audio_merge->sub_mgr;
+    sub_mgr->refcount = upipe_audio_merge_to_urefcount_real(upipe_audio_merge);
+    sub_mgr->signature = UPIPE_AUDIO_MERGE_INPUT_SIGNATURE;
+    sub_mgr->upipe_alloc = upipe_audio_merge_sub_alloc;
+    sub_mgr->upipe_input = upipe_audio_merge_sub_input;
+    sub_mgr->upipe_control = upipe_audio_merge_sub_control;
+    sub_mgr->upipe_mgr_control = NULL;
+}
+
+/** @internal @This allocates an audio_merge pipe.
+ *
+ * @param mgr common management structure
+ * @param uprobe structure used to raise events
+ * @param signature signature of the pipe allocator
+ * @param args optional arguments
+ * @return pointer to upipe or NULL in case of allocation error
+ */
+static struct upipe *upipe_audio_merge_alloc(struct upipe_mgr *mgr,
+                                             struct uprobe *uprobe,
+                                             uint32_t signature, va_list args)
+{
+    struct uref *flow_def;
+    struct upipe *upipe = upipe_audio_merge_alloc_flow(mgr,
+                            uprobe, signature, args, &flow_def);
+    if (unlikely(upipe == NULL))
+        return NULL;
+
+    struct upipe_audio_merge *upipe_audio_merge =
+                              upipe_audio_merge_from_upipe(upipe);
+    upipe_audio_merge_init_urefcount(upipe);
+    urefcount_init(upipe_audio_merge_to_urefcount_real(upipe_audio_merge),
+                   upipe_audio_merge_free);
+
+    upipe_audio_merge_init_upump_mgr(upipe);
+    upipe_audio_merge_init_upump(upipe);
+    upipe_audio_merge_init_output(upipe);
+    upipe_audio_merge_init_sub_mgr(upipe);
+    upipe_audio_merge_init_sub_inputs(upipe);
+    upipe_audio_merge_init_ubuf_mgr(upipe);
+
+    upipe_audio_merge->sub_flow_def = NULL;
+
+    upipe_audio_merge_store_flow_def(upipe, flow_def);
+
+    upipe_audio_merge_check_upump_mgr(upipe);
+
+    upipe_throw_ready(upipe);
+    return upipe;
+}
+
+/** @internal @This receives a provided ubuf manager.
+ *
+ * @param upipe description structure of the pipe
+ * @param flow_format amended flow format
+ * @return an error code
+ */
+static int upipe_audio_merge_check(struct upipe *upipe, struct uref *flow_format)
+{
+    struct upipe_audio_merge *upipe_audio_merge = upipe_audio_merge_from_upipe(upipe);
+    if (flow_format != NULL)
+        upipe_audio_merge_store_flow_def(upipe, flow_format);
+
+    if (upipe_audio_merge->flow_def == NULL)
+        return UBASE_ERR_NONE;
+
+    if (upipe_audio_merge->ubuf_mgr == NULL) {
+        upipe_audio_merge_require_ubuf_mgr(upipe, uref_dup(upipe_audio_merge->flow_def));
+        return UBASE_ERR_NONE;
+    }
+
+    return UBASE_ERR_NONE;
+}
+
+/** @internal @This processes control commands on an audio_merge pipe.
+ *
+ * @param upipe description structure of the pipe
+ * @param command type of command to process
+ * @param args arguments of the command
+ * @return an error code
+ */
+static int _upipe_audio_merge_control(struct upipe *upipe,
+                                     int command, va_list args)
+{
+    UBASE_HANDLED_RETURN(upipe_audio_merge_control_inputs(upipe, command, args));
+    UBASE_HANDLED_RETURN(upipe_audio_merge_control_output(upipe, command, args));
+
+    switch (command) {
+        case UPIPE_ATTACH_UPUMP_MGR:
+            upipe_audio_merge_set_upump(upipe, NULL);
+            return upipe_audio_merge_attach_upump_mgr(upipe);
+        case UPIPE_UNREGISTER_REQUEST:
+            return UBASE_ERR_NONE;
+        case UPIPE_GET_OUTPUT: {
+            struct upipe **p = va_arg(args, struct upipe **);
+            return upipe_audio_merge_get_output(upipe, p);
+        }
+        case UPIPE_SET_OUTPUT: {
+            struct upipe *output = va_arg(args, struct upipe *);
+            return upipe_audio_merge_set_output(upipe, output);
+        }
+
+        default:
+            return UBASE_ERR_UNHANDLED;
+    }
+}
+
+/** @internal @This processes control commands on an audio_merge pipe, and
+ * checks the status of the pipe afterwards.
+ *
+ * @param upipe description structure of the pipe
+ * @param command type of command to process
+ * @param args arguments of the command
+ * @return an error code
+ */
+static int upipe_audio_merge_control(struct upipe *upipe, int command, va_list args)
+{
+    UBASE_RETURN(_upipe_audio_merge_control(upipe, command, args));
+
+    return upipe_audio_merge_check(upipe, NULL);
+}
+
+/** @This frees a upipe.
+ *
+ * @param urefcount_real pointer to urefcount_real structure
+ */
+static void upipe_audio_merge_free(struct urefcount *urefcount_real)
+{
+    struct upipe_audio_merge *upipe_audio_merge =
+           upipe_audio_merge_from_urefcount_real(urefcount_real);
+    struct upipe *upipe = upipe_audio_merge_to_upipe(upipe_audio_merge);
+
+    upipe_throw_dead(upipe);
+
+    uref_free(upipe_audio_merge->sub_flow_def);
+    upipe_audio_merge_clean_upump(upipe);
+    upipe_audio_merge_clean_upump_mgr(upipe);
+    upipe_audio_merge_clean_output(upipe);
+    upipe_audio_merge_clean_sub_inputs(upipe);
+    urefcount_clean(urefcount_real);
+    upipe_audio_merge_clean_ubuf_mgr(upipe);
+    upipe_audio_merge_clean_urefcount(upipe);
+    upipe_audio_merge_free_flow(upipe);
+
+}
+
+/** @This is called when there is no external reference to the pipe anymore.
+ *
+ * @param upipe description structure of the pipe
+ */
+static void upipe_audio_merge_no_input(struct upipe *upipe)
+{
+    struct upipe_audio_merge *upipe_audio_merge =
+                              upipe_audio_merge_from_upipe(upipe);
+    urefcount_release(upipe_audio_merge_to_urefcount_real(upipe_audio_merge));
+}
+
+/** audio_merge module manager static descriptor */
+static struct upipe_mgr upipe_audio_merge_mgr = {
+    .refcount = NULL,
+    .signature = UPIPE_AUDIO_MERGE_SIGNATURE,
+
+    .upipe_alloc = upipe_audio_merge_alloc,
+    .upipe_input = NULL,
+    .upipe_control = upipe_audio_merge_control,
+
+    .upipe_mgr_control = NULL
+};
+
+/** @This returns the management structure for all audio_merge pipes.
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_audio_merge_mgr_alloc(void)
+{
+    return &upipe_audio_merge_mgr;
+}

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -59,15 +59,6 @@
 #include <string.h>
 #include <assert.h>
 
-#define UBUF_POOL_DEPTH 2
-
-#ifndef MIN
-# define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
-#ifndef MAX
-# define MAX(a,b) ((a) > (b) ? (a) : (b))
-#endif
-
 /** @hidden */
 static int upipe_audio_merge_check(struct upipe *upipe, struct uref *flow_format);
 
@@ -227,9 +218,8 @@ static struct upipe *upipe_audio_merge_sub_alloc(struct upipe_mgr *mgr,
 {
     struct upipe *upipe = upipe_audio_merge_sub_alloc_void(mgr,
                             uprobe, signature, args);
-    if (unlikely(upipe == NULL)) {
+    if (unlikely(upipe == NULL))
         return NULL;
-    }
 
     struct upipe_audio_merge_sub *upipe_audio_merge_sub =
                             upipe_audio_merge_sub_from_upipe(upipe);

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -149,7 +149,7 @@ UPIPE_HELPER_VOID(upipe_audio_merge_sub)
 UPIPE_HELPER_SUBPIPE(upipe_audio_merge, upipe_audio_merge_sub, input,
                      sub_mgr, inputs, uchain)
 
-/** @internal @Checks if two flow defs match, except for channel count
+/** @internal @Checks if two flow defs match for our purposes
  *
  * @param one first uref
  * @param two second uref
@@ -256,7 +256,7 @@ static int upipe_audio_merge_sub_control(struct upipe *upipe,
 /** @internal @Copies data from the input urefs to an output buffer.
  *
  * @param upipe description structure of the pipe
- * @param out_data the output buffer
+ * @param out_data reference to the output buffers
  */
 static void upipe_audio_merge_copy_to_output(struct upipe *upipe, float **out_data)
 {
@@ -312,9 +312,7 @@ static void upipe_audio_merge_copy_to_output(struct upipe *upipe, float **out_da
 /** @internal @Output a uref, if possible
  *
  * @param upipe description structure of the pipe
- * @param command type of command to process
- * @param args arguments of the command
- * @return an error code
+ * @param upump reference to upump structure
  */
 static void upipe_audio_merge_produce_output(struct upipe *upipe, struct upump **upump)
 {

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -254,17 +254,8 @@ static int upipe_audio_merge_sub_control(struct upipe *upipe,
                                          int command, va_list args)
 {
     UBASE_HANDLED_RETURN(upipe_audio_merge_sub_control_super(upipe, command, args));
+    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
     switch (command) {
-        case UPIPE_REGISTER_REQUEST: {
-            struct urequest *request = va_arg(args, struct urequest *);
-            return upipe_throw_provide_request(upipe, request);
-        }
-        case UPIPE_UNREGISTER_REQUEST:
-            return UBASE_ERR_NONE;
-        case UPIPE_SUB_GET_SUPER: {
-            struct upipe **p = va_arg(args, struct upipe **);
-            return upipe_audio_merge_sub_get_super(upipe, p);
-        }
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_audio_merge_sub_set_flow_def(upipe, flow_def);
@@ -502,11 +493,10 @@ static struct upipe *upipe_audio_merge_alloc(struct upipe_mgr *mgr,
 
     upipe_audio_merge->sub_flow_def = NULL;
 
+    upipe_throw_ready(upipe);
     upipe_audio_merge_store_flow_def(upipe, flow_def);
-
     upipe_audio_merge_check_upump_mgr(upipe);
 
-    upipe_throw_ready(upipe);
     return upipe;
 }
 
@@ -550,16 +540,6 @@ static int _upipe_audio_merge_control(struct upipe *upipe,
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_audio_merge_set_upump(upipe, NULL);
             return upipe_audio_merge_attach_upump_mgr(upipe);
-        case UPIPE_UNREGISTER_REQUEST:
-            return UBASE_ERR_NONE;
-        case UPIPE_GET_OUTPUT: {
-            struct upipe **p = va_arg(args, struct upipe **);
-            return upipe_audio_merge_get_output(upipe, p);
-        }
-        case UPIPE_SET_OUTPUT: {
-            struct upipe *output = va_arg(args, struct upipe *);
-            return upipe_audio_merge_set_output(upipe, output);
-        }
 
         default:
             return UBASE_ERR_UNHANDLED;

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -286,18 +286,20 @@ static void upipe_audio_merge_copy_to_output(struct upipe *upipe, float **out_da
         uint64_t input_num_samples = 0;
         UBASE_ERROR(upipe, uref_sound_flow_get_samples(upipe_audio_merge_sub->uref, &input_num_samples));
 
-
         /* If the samples of the input uref != our output sample size, throw an error and don't copy */
         if (unlikely(input_num_samples != output_num_samples))
             upipe_err_va(upipe, "input samples (%"PRIu64") != output samples (%"PRIu64")!",
                 input_num_samples, output_num_samples);
-        else
-            for (int i = 0; i < planes; i++)
+        else {
+            for (int i = 0; i < planes; i++) {
                 /* Only copy up to the number of channels in the output flowdef,
                 and thus what we've allocated */
-                if ((cur_plane + i) < output_channels)
+                if ((cur_plane + i) < output_channels) {
                     for (int j = 0; j < input_num_samples; j++)
                         out_data[cur_plane+i][j] = in_data[i][j];
+                }
+            }
+        }
         /* cur_plane is incremented outside of the loop in case we didn't copy, in which case we'd expect
            the plane(s) to be left blank in the output rather than removed */
         cur_plane += planes;
@@ -320,7 +322,6 @@ static void upipe_audio_merge_produce_output(struct upipe *upipe, struct upump *
     struct upipe_audio_merge *upipe_audio_merge = upipe_audio_merge_from_upipe(upipe);
     struct uchain *uchain;
     struct uref *output_uref = NULL;
-    int i;
     struct ubuf *ubuf;
 
     if (unlikely(upipe_audio_merge->ubuf_mgr == NULL))
@@ -373,7 +374,7 @@ static void upipe_audio_merge_produce_output(struct upipe *upipe, struct upump *
         return;
     }
     UBASE_ERROR(upipe, ubuf_sound_write_float(ubuf, 0, -1, out_data, output_channels));
-    for (i = 0; i < output_channels; i++)
+    for (int i = 0; i < output_channels; i++)
         memset(out_data[i], 0, sizeof(float) * output_num_samples);
 
     /* copy input data to output */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -105,7 +105,8 @@ check_PROGRAMS = \
 	upipe_block_to_sound_test \
 	upipe_audio_copy_test \
 	upipe_row_join_test \
-	upipe_auto_inner_test
+	upipe_auto_inner_test \
+	upipe_audio_merge_test
 
 TESTS = \
 	ulist_test \
@@ -164,7 +165,8 @@ TESTS = \
 	upipe_block_to_sound_test \
 	upipe_audio_copy_test \
 	upipe_row_join_test \
-	upipe_auto_inner_test
+	upipe_auto_inner_test \
+	upipe_audio_merge_test
 
 if HAVE_EBUR128
 check_PROGRAMS += upipe_ebur128_test
@@ -456,6 +458,7 @@ upipe_v210enc_test_CFLAGS = $(AM_CFLAGS) $(AVUTIL_CFLAGS)
 upipe_v210dec_test_CFLAGS = $(AM_CFLAGS) $(AVUTIL_CFLAGS)
 upipe_row_split_test_LDADD = $(LDADD) -lev $(top_builddir)/lib/upump-ev/libupump_ev.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
 upipe_separate_fields_test_LDADD = $(LDADD) -lev $(top_builddir)/lib/upump-ev/libupump_ev.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
+upipe_audio_merge_test_LDADD = $(LDADD) $(top_builddir)/lib/upipe-modules/libupipe_modules.la
 
 upipe_avformat_test_CFLAGS = $(AM_CFLAGS) $(AVFORMAT_CFLAGS)
 upipe_avformat_test_LDADD = $(LDADD) -lev $(top_builddir)/lib/upump-ev/libupump_ev.la $(top_builddir)/lib/upipe-av/libupipe_av.la $(AVFORMAT_LIBS)

--- a/tests/upipe_audio_merge_test.c
+++ b/tests/upipe_audio_merge_test.c
@@ -91,7 +91,6 @@ static int catch(struct uprobe *uprobe, struct upipe *upipe,
     switch (event) {
         default:
             printf("event: %d\n", event);
-            //assert(0);
             break;
         case UPROBE_READY:
         case UPROBE_DEAD:

--- a/tests/upipe_audio_merge_test.c
+++ b/tests/upipe_audio_merge_test.c
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2014-2016 OpenHeadend S.A.R.L.
+ *               2019 Open Broadcast Systems Ltd.
+ *
+ * Authors: Benjamin Cohen
+ *          Christophe Massiot
+ *          Sam Willcocks
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/** @file
+ * @short unit tests for audio merge pipes
+ */
+
+#undef NDEBUG
+
+#include <upipe/uprobe.h>
+#include <upipe/uprobe_stdio.h>
+#include <upipe/uprobe_prefix.h>
+#include <upipe/uprobe_ubuf_mem.h>
+#include <upipe/umem.h>
+#include <upipe/umem_alloc.h>
+#include <upipe/udict.h>
+#include <upipe/udict_inline.h>
+#include <upipe/uref.h>
+#include <upipe/uref_dump.h>
+#include <upipe/uref_std.h>
+#include <upipe/uref_flow.h>
+#include <upipe/uref_sound.h>
+#include <upipe/uref_sound_flow.h>
+#include <upipe/ubuf_mem.h>
+#include <upipe/upipe.h>
+#include <upipe-modules/upipe_audio_merge.h>
+#include <upipe/uprobe_uref_mgr.h>
+#include <upipe/ubuf_sound_mem.h>
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#define UDICT_POOL_DEPTH    0
+#define UREF_POOL_DEPTH     0
+#define UBUF_POOL_DEPTH     0
+#define SAMPLES             1024
+#define UPROBE_LOG_LEVEL    UPROBE_LOG_VERBOSE
+
+// Fill ubuf with dummy data. the offset is arbitrary
+static void fill_in(struct ubuf *ubuf, uint8_t offset)
+{
+    size_t size;
+    uint8_t sample_size;
+    ubase_assert(ubuf_sound_size(ubuf, &size, &sample_size));
+
+    const char *channel = NULL;
+    while (ubase_check(ubuf_sound_iterate_plane(ubuf, &channel)) &&
+           channel != NULL) {
+        float *buffer;
+        ubase_assert(ubuf_sound_plane_write_float(ubuf, channel, 0, -1,
+                                                    &buffer));
+
+        for (int x = 0; x < size; x++)
+            buffer[x] = (float)(x + offset);
+        ubase_assert(ubuf_sound_plane_unmap(ubuf, channel, 0, -1));
+    }
+}
+
+/** definition of our uprobe */
+static int catch(struct uprobe *uprobe, struct upipe *upipe,
+                 int event, va_list args)
+{
+    switch (event) {
+        default:
+            printf("event: %d\n", event);
+            //assert(0);
+            break;
+        case UPROBE_READY:
+        case UPROBE_DEAD:
+        case UPROBE_NEW_FLOW_DEF:
+        case UPROBE_SOURCE_END:
+            break;
+    }
+    return UBASE_ERR_NONE;
+}
+
+/** helper phony pipe */
+static struct upipe *test_alloc(struct upipe_mgr *mgr, struct uprobe *uprobe,
+                                uint32_t signature, va_list args)
+{
+    struct upipe *upipe = malloc(sizeof(struct upipe));
+    assert(upipe != NULL);
+    upipe_init(upipe, mgr, uprobe);
+    return upipe;
+}
+
+/** helper phony pipe */
+static void test_input(struct upipe *upipe, struct uref *uref,
+                       struct upump **upump_p)
+{
+    assert(uref != NULL);
+    const float *r;
+
+    ubase_assert(uref_sound_plane_read_float(uref, "l", 0, -1, &r));
+    assert(r[0] == '0');
+    assert(r[5] == '0' + 5);
+    assert(r[11] == '0' + 11);
+    ubase_assert(uref_sound_plane_unmap(uref, "l", 0, -1));
+
+    ubase_assert(uref_sound_plane_read_float(uref, "r", 0, -1, &r));
+    assert(r[0] == '1');
+    assert(r[7] == '1' + 7);
+    assert(r[18] == '1' + 18);
+    ubase_assert(uref_sound_plane_unmap(uref, "r", 0, -1));
+    uref_free(uref);
+}
+
+/** helper phony pipe */
+static int test_control(struct upipe *upipe, int command, va_list args)
+{
+    switch (command) {
+        case UPIPE_REGISTER_REQUEST: {
+            struct urequest *urequest = va_arg(args, struct urequest *);
+            return upipe_throw_provide_request(upipe, urequest);
+        }
+        case UPIPE_UNREGISTER_REQUEST:
+            return UBASE_ERR_NONE;
+        case UPIPE_SET_FLOW_DEF:
+            return UBASE_ERR_NONE;
+        default:
+            assert(0);
+            return UBASE_ERR_UNHANDLED;
+    }
+}
+
+/** helper phony pipe */
+static void test_free(struct upipe *upipe)
+{
+    upipe_clean(upipe);
+    free(upipe);
+}
+
+/** helper phony pipe */
+static struct upipe_mgr merge_test_mgr = {
+    .refcount = NULL,
+    .upipe_alloc = test_alloc,
+    .upipe_input = test_input,
+    .upipe_control = test_control
+};
+
+int main(int argc, char *argv[])
+{
+    /* upipe env */
+    struct umem_mgr *umem_mgr = umem_alloc_mgr_alloc();
+    assert(umem_mgr != NULL);
+    struct udict_mgr *udict_mgr = udict_inline_mgr_alloc(UDICT_POOL_DEPTH,
+                                                         umem_mgr, -1, -1);
+    assert(udict_mgr != NULL);
+    struct uref_mgr *uref_mgr = uref_std_mgr_alloc(UREF_POOL_DEPTH, udict_mgr,
+                                                   0);
+    assert(uref_mgr != NULL);
+
+    struct uref *uref;
+    struct uprobe uprobe;
+    uprobe_init(&uprobe, catch, NULL);
+    struct uprobe *logger = uprobe_stdio_alloc(&uprobe, stderr,
+                                               UPROBE_LOG_LEVEL);
+    assert(logger != NULL);
+    logger = uprobe_uref_mgr_alloc(logger, uref_mgr);
+    assert(logger != NULL);
+    logger = uprobe_ubuf_mem_alloc(logger, umem_mgr, UBUF_POOL_DEPTH,
+                                               UBUF_POOL_DEPTH);
+    assert(logger != NULL);
+
+    /* test pipes */
+    struct upipe *upipe_sink = upipe_void_alloc(&merge_test_mgr,
+                                                 uprobe_use(logger));
+    assert(upipe_sink != NULL);
+
+    /* merge superpipe */
+    struct uref *output_flow = uref_sound_flow_alloc_def(uref_mgr, "f32.", 1, 4);
+    assert(output_flow);
+    ubase_assert(uref_sound_flow_set_rate(output_flow, 48000));
+    ubase_assert(uref_sound_flow_set_samples(output_flow, SAMPLES));
+
+    /* before we add channels/planes duplicate the flowdef for out input flow defs */
+    struct uref *flow0 = uref_dup(output_flow);
+    struct uref *flow1 = uref_dup(output_flow);
+
+    ubase_assert(uref_sound_flow_add_plane(output_flow, "l"));
+    ubase_assert(uref_sound_flow_add_plane(output_flow, "r"));
+    ubase_assert(uref_sound_flow_set_channels(output_flow, 2));
+    struct upipe_mgr *upipe_audio_merge_mgr = upipe_audio_merge_mgr_alloc();
+    assert(upipe_audio_merge_mgr != NULL);
+    struct upipe *upipe_audio_merge = upipe_flow_alloc(upipe_audio_merge_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "merge"), output_flow);
+    assert(upipe_audio_merge != NULL);
+
+    /* connect output of merge pipe to sink */
+    ubase_assert(upipe_set_output(upipe_audio_merge, upipe_sink));
+
+    /* merge subpipe 0 */
+    ubase_assert(uref_sound_flow_add_plane(flow0, "l"));
+    ubase_assert(uref_sound_flow_set_channels(flow0, 1));
+    uref_dump(flow0, logger);
+    struct upipe *upipe_audio_merge_input0 = upipe_void_alloc_sub(upipe_audio_merge,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL,
+                             "merge input 0"));
+    assert(upipe_audio_merge_input0 != NULL);
+    ubase_assert(upipe_set_flow_def(upipe_audio_merge_input0, flow0));
+
+    /* merge subpipe 1 */
+    ubase_assert(uref_sound_flow_add_plane(flow1, "r"));
+    ubase_assert(uref_sound_flow_set_channels(flow1, 1));
+    uref_dump(flow1, logger);
+    struct upipe *upipe_audio_merge_input1 = upipe_void_alloc_sub(upipe_audio_merge,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL,
+                             "merge input 1"));
+    assert(upipe_audio_merge_input1 != NULL);
+    ubase_assert(upipe_set_flow_def(upipe_audio_merge_input1, flow1));
+
+    uref_free(output_flow);
+
+    /* input 0 sound ubuf manager */
+    struct ubuf_mgr *sound_mgr_0 = ubuf_mem_mgr_alloc_from_flow_def(
+                 UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, flow0);
+    assert(sound_mgr_0);
+
+    /* feed samples to input 0 */
+    uref = uref_sound_alloc(uref_mgr, sound_mgr_0, SAMPLES);
+    assert(uref != NULL);
+    fill_in(uref->ubuf, (uint8_t)'0'); // Use the integer value of char '0' as the offset
+    ubase_assert(uref_sound_flow_set_samples(uref, SAMPLES));
+    upipe_input(upipe_audio_merge_input0, uref, NULL);
+
+    /* input 1 sound ubuf manager */
+    struct ubuf_mgr *sound_mgr_1 = ubuf_mem_mgr_alloc_from_flow_def(
+                 UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, flow1);
+    assert(sound_mgr_1);
+
+    /* feed samples to input 1 */
+    uref = uref_sound_alloc(uref_mgr, sound_mgr_1, SAMPLES);
+    assert(uref != NULL);
+    fill_in(uref->ubuf, (uint8_t)'1');
+    ubase_assert(uref_sound_flow_set_samples(uref, SAMPLES));
+    upipe_input(upipe_audio_merge_input1, uref, NULL);
+
+    upipe_release(upipe_audio_merge_input0);
+    upipe_release(upipe_audio_merge_input1);
+
+    /* clean */
+    uref_free(flow0);
+    uref_free(flow1);
+    ubuf_mgr_release(sound_mgr_0);
+    ubuf_mgr_release(sound_mgr_1);
+    upipe_release(upipe_audio_merge);
+    upipe_mgr_release(upipe_audio_merge_mgr); // nop
+
+    test_free(upipe_sink);
+
+    uref_mgr_release(uref_mgr);
+    udict_mgr_release(udict_mgr);
+    umem_mgr_release(umem_mgr);
+
+    uprobe_release(logger);
+    uprobe_clean(&uprobe);
+    return 0;
+}


### PR DESCRIPTION
Adds audio_merge pipe which accepts planar audio from input subpipes and outputs a single stream of multiplanar audio.
Adds test for audio_merge pipe