### PR TITLE
include/upipe/ubase: fix doxy comment for ubase_clip

### DIFF
--- a/include/upipe/ubase.h
+++ b/include/upipe/ubase.h
@@ -511,14 +511,16 @@ static inline uint32_t ubase_get_signature(va_list args)
 
 /** @This clips an integer into the given range
  *
- * @param args the va list to copy from
- * @return a signature
+ * @param i integer value
+ * @param min minimum value
+ * @param max maximum value
+ * @return an integer
  */
 static inline int ubase_clip(int i, int min, int max)
 {
     if      (i < min) return min;
     else if (i > max) return max;
-    else               return i;
+    else              return i;
 }
 
 


### PR DESCRIPTION
Also fix alignment of return statement.