### PR TITLE
upipe-ebur128: check input rate value

### DIFF
--- a/lib/upipe-ebur128/upipe_ebur128.c
+++ b/lib/upipe-ebur128/upipe_ebur128.c
@@ -249,7 +249,8 @@ static int upipe_ebur128_set_flow_def(struct upipe *upipe,
                  !ubase_check(uref_sound_flow_get_channels(flow,
                      &upipe_ebur128->channels)) ||
                  !ubase_check(uref_sound_flow_get_planes(flow,
-                     &upipe_ebur128->planes))))
+                     &upipe_ebur128->planes)) ||
+                 !rate))
         return UBASE_ERR_INVALID;
 
     struct uref *flow_dup;


### PR DESCRIPTION
If rate is zero, libebur128 state allocation fails and returns NULL.
Then the next input buffer will trigger a SEGV.