### PR TITLE
audio_merge: Make audio channel mismatch message verbose

### DIFF
--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -356,7 +356,7 @@ static void upipe_audio_merge_produce_output(struct upipe *upipe, struct upump *
     uint8_t output_channels = 0;
     UBASE_ERROR(upipe, uref_sound_flow_get_channels(upipe_audio_merge->flow_def, &output_channels));
     if (input_channels != output_channels)
-        upipe_err_va(upipe, "total input channels (%"PRIu64") != output flow def (%d), some will be skipped or blanked!",
+        upipe_verbose_va(upipe, "total input channels (%"PRIu64") != output flow def (%d), some will be skipped or blanked!",
             input_channels, output_channels);
 
     uint64_t output_num_samples = 0;


### PR DESCRIPTION
It's not an error, there are use-cases for this