### PR TITLE
upipe-ts: fix AC-3 when conformance is ATSC

### DIFF
--- a/include/upipe/ubase.h
+++ b/include/upipe/ubase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2015 OpenHeadend S.A.R.L.
+ * Copyright (C) 2012-2019 OpenHeadend S.A.R.L.
  *
  * Authors: Christophe Massiot
  *
@@ -87,6 +87,14 @@ extern "C" {
 
 /** @This is used to retrieve the number of items of an array. */
 #define UBASE_ARRAY_SIZE(a)        (sizeof (a) / sizeof ((a)[0]))
+
+/** @This iterates the items of a fixed size array.
+ *
+ * @param a the array to iterate
+ * @param item array iterator
+ */
+#define ubase_array_foreach(a, item)                                        \
+    for (item = a; (item - a) < UBASE_ARRAY_SIZE(a); item++)
 
 /** @This declares two functions dealing with substructures included into a
  * larger structure.

--- a/lib/upipe-ts/upipe_ts_mux.c
+++ b/lib/upipe-ts/upipe_ts_mux.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2017 OpenHeadend S.A.R.L.
+ * Copyright (C) 2013-2019 OpenHeadend S.A.R.L.
  *
  * Authors: Christophe Massiot
  *
@@ -1078,8 +1078,12 @@ static int upipe_ts_mux_input_set_flow_def(struct upipe *upipe,
                 upipe_ts_mux_program_to_upipe(program)->mgr);
     const char *def;
     uint64_t octetrate;
-    UBASE_RETURN(uref_flow_get_def(flow_def, &def))
 
+    UBASE_RETURN(uref_ts_flow_set_conformance(
+            flow_def,
+            upipe_ts_conformance_to_string(upipe_ts_mux->conformance)));
+
+    UBASE_RETURN(uref_flow_get_def(flow_def, &def))
     if (!ubase_ncmp(def, "void.scte35.")) {
         octetrate = 0;
 


### PR DESCRIPTION
This commit depends on bitstream commit
8232e05cbe1258745bace6094540adb0cd392dad.