### PR TITLE
Fixed C++ malloc compatibility in public headers

### DIFF
--- a/include/upipe/upipe_helper_bin_input.h
+++ b/include/upipe/upipe_helper_bin_input.h
@@ -243,7 +243,8 @@ static int STRUCTURE##_provide_bin_proxy(struct urequest *urequest,         \
 static int STRUCTURE##_alloc_bin_proxy(struct upipe *upipe,                 \
                                        struct urequest *urequest)           \
 {                                                                           \
-    struct urequest *proxy = malloc(sizeof(struct urequest));               \
+    struct urequest *proxy =                                                \
+        (struct urequest *)malloc(sizeof(struct urequest));                 \
     UBASE_ALLOC_RETURN(proxy);                                              \
     urequest_set_opaque(proxy, urequest);                                   \
     struct uref *uref = NULL;                                               \

--- a/include/upipe/upipe_helper_iconv.h
+++ b/include/upipe/upipe_helper_iconv.h
@@ -103,7 +103,7 @@ static void STRUCTURE##_init_iconv(struct upipe *upipe)                     \
 static char *STRUCTURE##_iconv_append_null(const char *string,              \
                                            size_t length)                   \
 {                                                                           \
-    char *output = malloc(length + 1);                                      \
+    char *output = (char *)malloc(length + 1);                              \
     if (unlikely(output == NULL))                                           \
         return NULL;                                                        \
     memcpy(output, string, length);                                         \
@@ -146,7 +146,7 @@ static char *STRUCTURE##_iconv_wrapper(void *_upipe, const char *encoding,  \
                                                                             \
     /* converted strings can be up to six times larger */                   \
     out_length = length * 6;                                                \
-    p = output = malloc(out_length);                                        \
+    p = output = (char *)malloc(out_length);                                \
     if (unlikely(p == NULL)) {                                              \
         upipe_err(upipe, "couldn't allocate");                              \
         return STRUCTURE##_iconv_append_null(string, length);               \

--- a/include/upipe/uprobe_helper_alloc.h
+++ b/include/upipe/uprobe_helper_alloc.h
@@ -65,45 +65,46 @@ extern "C" {
  * @param STRUCTURE name of your public uprobe super-structure
  * your private uprobe structure
  */
-#define UPROBE_HELPER_ALLOC(STRUCTURE)                                      \
-/** @This is a super-set of the STRUCTURE with additional urefcount. */     \
-struct STRUCTURE##_alloc {                                                  \
-    /** refcount management structure */                                    \
-    struct urefcount urefcount;                                             \
-    /** main structure */                                                   \
-    struct STRUCTURE STRUCTURE;                                             \
-};                                                                          \
-UBASE_FROM_TO(STRUCTURE##_alloc, STRUCTURE, STRUCTURE, STRUCTURE)           \
-UBASE_FROM_TO(STRUCTURE##_alloc, urefcount, urefcount, urefcount)           \
-/** @internal @This frees the allocated probe.                              \
- *                                                                          \
- * @param urefcount pointer to urefcount structure                          \
- */                                                                         \
-static void STRUCTURE##_free(struct urefcount *urefcount)                   \
-{                                                                           \
-    struct STRUCTURE##_alloc *s =                                           \
-        STRUCTURE##_alloc_from_urefcount(urefcount);                        \
-    STRUCTURE##_clean(STRUCTURE##_alloc_to_##STRUCTURE(s));                 \
-    free(s);                                                                \
-}                                                                           \
-/** @This allocates a probe with a dedicated urefcount.                     \
- *                                                                          \
- * @return pointer to probe                                                 \
- */                                                                         \
-struct uprobe *STRUCTURE##_alloc(ARGS_DECL)                                 \
-{                                                                           \
-    struct STRUCTURE##_alloc *s = malloc(sizeof(struct STRUCTURE##_alloc)); \
-    if (unlikely(s == NULL))                                                \
-        return NULL;                                                        \
-    struct uprobe *uprobe =                                                 \
-        STRUCTURE##_init(STRUCTURE##_alloc_to_##STRUCTURE(s), ARGS);        \
-    if (unlikely(uprobe == NULL)) {                                         \
-        free(s);                                                            \
-        return NULL;                                                        \
-    }                                                                       \
-    urefcount_init(STRUCTURE##_alloc_to_urefcount(s), STRUCTURE##_free);    \
-    uprobe->refcount = STRUCTURE##_alloc_to_urefcount(s);                   \
-    return uprobe;                                                          \
+#define UPROBE_HELPER_ALLOC(STRUCTURE)                                        \
+/** @This is a super-set of the STRUCTURE with additional urefcount. */       \
+struct STRUCTURE##_alloc {                                                    \
+    /** refcount management structure */                                      \
+    struct urefcount urefcount;                                               \
+    /** main structure */                                                     \
+    struct STRUCTURE STRUCTURE;                                               \
+};                                                                            \
+UBASE_FROM_TO(STRUCTURE##_alloc, STRUCTURE, STRUCTURE, STRUCTURE)             \
+UBASE_FROM_TO(STRUCTURE##_alloc, urefcount, urefcount, urefcount)             \
+/** @internal @This frees the allocated probe.                                \
+ *                                                                            \
+ * @param urefcount pointer to urefcount structure                            \
+ */                                                                           \
+static void STRUCTURE##_free(struct urefcount *urefcount)                     \
+{                                                                             \
+    struct STRUCTURE##_alloc *s =                                             \
+        STRUCTURE##_alloc_from_urefcount(urefcount);                          \
+    STRUCTURE##_clean(STRUCTURE##_alloc_to_##STRUCTURE(s));                   \
+    free(s);                                                                  \
+}                                                                             \
+/** @This allocates a probe with a dedicated urefcount.                       \
+ *                                                                            \
+ * @return pointer to probe                                                   \
+ */                                                                           \
+struct uprobe *STRUCTURE##_alloc(ARGS_DECL)                                   \
+{                                                                             \
+    struct STRUCTURE##_alloc *s =                                             \
+        (struct STRUCTURE##_alloc *)malloc(sizeof(struct STRUCTURE##_alloc)); \
+    if (unlikely(s == NULL))                                                  \
+        return NULL;                                                          \
+    struct uprobe *uprobe =                                                   \
+        STRUCTURE##_init(STRUCTURE##_alloc_to_##STRUCTURE(s), ARGS);          \
+    if (unlikely(uprobe == NULL)) {                                           \
+        free(s);                                                              \
+        return NULL;                                                          \
+    }                                                                         \
+    urefcount_init(STRUCTURE##_alloc_to_urefcount(s), STRUCTURE##_free);      \
+    uprobe->refcount = STRUCTURE##_alloc_to_urefcount(s);                     \
+    return uprobe;                                                            \
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This was already done for some of the upipe_helper headers, this does it for the rest.

I confirmed that upipe compiles, that "make check" reports all tests are still successful, and that this change fixes including from C++.