### PR TITLE
uprobe_selflow: keep sub probe when source end

### DIFF
--- a/lib/upipe/uprobe_select_flows.c
+++ b/lib/upipe/uprobe_select_flows.c
@@ -311,11 +311,8 @@ static int uprobe_selflow_sub_throw(struct uprobe *uprobe,
     struct uprobe_selflow_sub *sub =
         uprobe_selflow_sub_from_uprobe(uprobe);
     assert(subpipe == sub->subpipe);
-    ulist_delete(uprobe_selflow_sub_to_uchain(sub));
-    uref_free(sub->flow_def);
     sub->subpipe = NULL;
     upipe_release(subpipe);
-    uprobe_release(uprobe_selflow_sub_to_uprobe(sub));
     return UBASE_ERR_NONE;
 }
 


### PR DESCRIPTION
Don't release the sub probe when the sub pipe ends. If the sub probe is
released when the source ends it will prevent the next SPLIT_UPDATE to
select a new pipe because need_update will be false.