### PR TITLE
upipe_speexdsp: check that the ubuf_mgr exists before using it

### DIFF
--- a/lib/upipe-speexdsp/upipe_speexdsp.c
+++ b/lib/upipe-speexdsp/upipe_speexdsp.c
@@ -126,6 +126,11 @@ static bool upipe_speexdsp_handle(struct upipe *upipe, struct uref *uref,
 {
     struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
 
+    if (!upipe_speexdsp->ubuf_mgr) {
+        upipe_warn(upipe, "no ubuf_mgr, holding input uref");
+        return false;
+    }
+
     struct urational drift_rate;
     if (!ubase_check(uref_clock_get_rate(uref, &drift_rate)))
         drift_rate = (struct urational){ 1, 1 };


### PR DESCRIPTION
Drop input urefs if it doesn't exist.

On IRC I asked about the following problem: "I need to deport upipe_speexdsp to a worker thread but it doesn't get a ubuf_mgr before trying to create a ubuf with it which causes an assert.  What is the preferred way to have the pipe check whether it is ready to handle input urefs?"

This is what I quickly put together for our usage because I wasn't sure how else to handle it.