### PR TITLE
upipe_filter_vanc: VANC is left-justified, don't waste cpu searching …

### DIFF
--- a/lib/upipe-filters/upipe_filter_vanc.c
+++ b/lib/upipe-filters/upipe_filter_vanc.c
@@ -796,7 +796,7 @@ static void upipe_vanc_process_line(struct upipe *upipe, struct uref *uref,
         if (r[0] != S291_ADF1 || r[1] != S291_ADF2 || r[2] != S291_ADF3) {
             r++;
             hsize--;
-            continue;
+            break;
         }
 
         uint8_t did = s291_get_did(r);


### PR DESCRIPTION
…the entire line