### PR TITLE
upipe_filter_encode: fix random set_flow_def failure

### DIFF
--- a/lib/upipe-filters/upipe_filter_encode.c
+++ b/lib/upipe-filters/upipe_filter_encode.c
@@ -224,6 +224,7 @@ static struct upipe *upipe_fenc_alloc(struct upipe_mgr *mgr,
     upipe_fenc_init_bin_output(upipe);
     upipe_fenc->flow_def_input = flow_def_input;
     upipe_fenc->options = NULL;
+    upipe_fenc->bit_depth = 0;
     upipe_fenc->preset = NULL;
     upipe_fenc->tune = NULL;
     upipe_fenc->profile = NULL;


### PR DESCRIPTION
The uninitialized bit_depth could trigger a failing control on non-x265
inner pipes.