### PR TITLE
upipe_h264f: fix invalid behaviours

### DIFF
--- a/lib/upipe-framers/upipe_h264_framer.c
+++ b/lib/upipe-framers/upipe_h264_framer.c
@@ -2444,6 +2444,7 @@ static void upipe_h264f_work_annexb(struct upipe *upipe, struct upump **upump_p)
 
     upipe_h264f_end_annexb(upipe, upump_p);
     upipe_h264f_output_annexb(upipe, upump_p);
+    upipe_h264f->au_last_nal_offset = -1;
 }
 
 /** @internal @This prepares a raw access unit.


### PR DESCRIPTION
Fix invalid behaviours on a Adobe Premiere TS file