### PR TITLE
upipe_audio_max: avoid implicit float conversion

### DIFF
--- a/lib/upipe-filters/upipe_audio_max.c
+++ b/lib/upipe-filters/upipe_audio_max.c
@@ -120,7 +120,7 @@ static double upipe_amax_process_##type(struct upipe *upipe,                \
             max = -c;                                                       \
     }                                                                       \
     uref_sound_plane_unmap(uref, channel, 0, -1);                           \
-    return (max * 1.0f) / type_max;                                         \
+    return max * 1. / type_max;                                             \
 }
 UPIPE_AMAX_TEMPLATE(uint8_t, UINT8_MAX)
 UPIPE_AMAX_TEMPLATE(int16_t, INT16_MAX)

--- a/tests/upipe_audio_max_test.c
+++ b/tests/upipe_audio_max_test.c
@@ -96,9 +96,9 @@ static void test_input(struct upipe *upipe, struct uref *uref,
     uref_dump(uref, upipe->uprobe);
     double amplitude;
     ubase_assert(uref_amax_get_amplitude(uref, &amplitude, 0));
-    assert(amplitude == (SAMPLES - 1) * 1.0f / INT16_MAX);
+    assert(amplitude == (SAMPLES - 1) * 1. / INT16_MAX);
     ubase_assert(uref_amax_get_amplitude(uref, &amplitude, 1));
-    assert(amplitude == (SAMPLES * 2 - 1) * 1.0f / INT16_MAX);
+    assert(amplitude == (SAMPLES * 2 - 1) * 1. / INT16_MAX);
 
     uref_free(uref);
     got_input = true;


### PR DESCRIPTION
Avoid changing INT32_MAX value from 2147483647 to 2147483648 due to
implicit float conversion. Use double instead.