### PR TITLE
upipe_mpgaf: fix potential assert

### DIFF
--- a/lib/upipe-framers/upipe_mpga_framer.c
+++ b/lib/upipe-framers/upipe_mpga_framer.c
@@ -1859,8 +1859,12 @@ static void upipe_mpgaf_input(struct upipe *upipe, struct uref *uref,
 static int upipe_mpgaf_check_flow_format(struct upipe *upipe,
                                          struct uref *flow_format)
 {
+    struct upipe_mpgaf *upipe_mpgaf = upipe_mpgaf_from_upipe(upipe);
     if (flow_format == NULL)
         return UBASE_ERR_INVALID;
+
+    uref_free(upipe_mpgaf->flow_def_requested);
+    upipe_mpgaf->flow_def_requested = NULL;
 
     upipe_mpgaf_require_ubuf_mgr(upipe, flow_format);
     return UBASE_ERR_NONE;


### PR DESCRIPTION
Reset flow_def_requested when a new flow format is provided as it is
used to check if the pipe can handle new urefs. Because the provided
flow format will unset the ubuf manager before requiring a new one, the
pipe must wait for the new ubuf manager before handling new urefs.