### PR TITLE
ubuf_pic: improve ubuf_pic_clear

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,6 +70,7 @@ check_PROGRAMS = \
 	ubuf_block_mem_test \
 	ubuf_pic_mem_test \
 	ubuf_sound_mem_test \
+	ubuf_pic_clear_test \
 	uref_std_test \
 	uref_uri_test \
 	uclock_std_test \
@@ -121,6 +122,7 @@ TESTS = \
 	ubuf_block_mem_test \
 	ubuf_pic_mem_test \
 	ubuf_sound_mem_test \
+	ubuf_pic_clear_test \
 	uprobe_stdio_test.sh \
 	uprobe_syslog_test.sh \
 	uprobe_prefix_test.sh \

--- a/tests/ubuf_pic_clear_test.c
+++ b/tests/ubuf_pic_clear_test.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2020 EasyTools
+ *
+ * Authors: Clément Vasseur
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/** @file
+ * @short unit tests for picture clear
+ */
+
+#undef NDEBUG
+
+#include <upipe/umem.h>
+#include <upipe/umem_alloc.h>
+#include <upipe/ubuf.h>
+#include <upipe/ubuf_pic.h>
+#include <upipe/ubuf_pic_mem.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#define UBUF_POOL_DEPTH     1
+#define UBUF_PREPEND        2
+#define UBUF_APPEND         2
+#define UBUF_ALIGN          16
+#define UBUF_ALIGN_HOFFSET  0
+
+static void fill_in(struct ubuf *ubuf)
+{
+    size_t hsize, vsize;
+    uint8_t macropixel;
+    ubase_assert(ubuf_pic_size(ubuf, &hsize, &vsize, &macropixel));
+
+    const char *chroma;
+    ubuf_pic_foreach_plane(ubuf, chroma) {
+        size_t stride;
+        uint8_t hsub, vsub, macropixel_size;
+        ubase_assert(ubuf_pic_plane_size(ubuf, chroma, &stride, &hsub, &vsub,
+                                         &macropixel_size));
+        int hoctets = hsize * macropixel_size / hsub / macropixel;
+        uint8_t *buffer;
+        ubase_assert(ubuf_pic_plane_write(ubuf, chroma, 0, 0, -1, -1, &buffer));
+
+        for (int y = 0; y < vsize / vsub; y++) {
+            for (int x = 0; x < hoctets; x++)
+                buffer[x] = 1 + (y * hoctets) + x;
+            buffer += stride;
+        }
+        ubase_assert(ubuf_pic_plane_unmap(ubuf, chroma, 0, 0, -1, -1));
+    }
+}
+
+static void check(struct ubuf *ubuf, const char *chroma,
+                  uint8_t *pattern, size_t pattern_size)
+{
+    size_t hsize, vsize;
+    uint8_t macropixel;
+    ubase_assert(ubuf_pic_size(ubuf, &hsize, &vsize, &macropixel));
+
+    size_t stride;
+    uint8_t hsub, vsub, macropixel_size;
+    ubase_assert(ubuf_pic_plane_size(ubuf, chroma, &stride, &hsub, &vsub,
+                                     &macropixel_size));
+    int hoctets = hsize * macropixel_size / hsub / macropixel;
+    const uint8_t *buffer;
+    ubase_assert(ubuf_pic_plane_read(ubuf, chroma, 0, 0, -1, -1, &buffer));
+
+    for (int y = 0; y < vsize / vsub; y++) {
+        for (int x = 0; x < hoctets; x += pattern_size)
+            assert(!memcmp(buffer + x, pattern, pattern_size));
+        buffer += stride;
+    }
+    ubase_assert(ubuf_pic_plane_unmap(ubuf, chroma, 0, 0, -1, -1));
+}
+
+int main(int argc, char **argv)
+{
+    struct umem_mgr *umem_mgr = umem_alloc_mgr_alloc();
+    assert(umem_mgr != NULL);
+
+    struct ubuf_mgr *mgr;
+    struct ubuf *ubuf;
+
+    /* yuv420p */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "y8", 1, 1, 1));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "u8", 2, 2, 1));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "v8", 2, 2, 1));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "y8", (uint8_t []){ 16 }, 1);
+    check(ubuf, "u8", (uint8_t []){ 128 }, 1);
+    check(ubuf, "v8", (uint8_t []){ 128 }, 1);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "y8", (uint8_t []){ 0 }, 1);
+    check(ubuf, "u8", (uint8_t []){ 128 }, 1);
+    check(ubuf, "v8", (uint8_t []){ 128 }, 1);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* yuv422p */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "y8", 1, 1, 1));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "u8", 2, 1, 1));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "v8", 2, 1, 1));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "y8", (uint8_t []){ 16 }, 1);
+    check(ubuf, "u8", (uint8_t []){ 128 }, 1);
+    check(ubuf, "v8", (uint8_t []){ 128 }, 1);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "y8", (uint8_t []){ 0 }, 1);
+    check(ubuf, "u8", (uint8_t []){ 128 }, 1);
+    check(ubuf, "v8", (uint8_t []){ 128 }, 1);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* nv12 */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "y8", 1, 1, 1));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "u8v8", 2, 2, 2));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "y8", (uint8_t []){ 16 }, 1);
+    check(ubuf, "u8v8", (uint8_t []){ 128 }, 1);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "y8", (uint8_t []){ 0 }, 1);
+    check(ubuf, "u8v8", (uint8_t []){ 128 }, 1);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* rgba */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "r8g8b8a8", 1, 1, 4));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "r8g8b8a8", (uint8_t []){ 16, 16, 16, 16 }, 4);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "r8g8b8a8", (uint8_t []){ 0, 0, 0, 0 }, 4);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* yuv420p10le */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "y10l", 1, 1, 2));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "u10l", 2, 2, 2));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "v10l", 2, 2, 2));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "y10l", (uint8_t []){ 64, 0 }, 2);
+    check(ubuf, "u10l", (uint8_t []){ 0, 2 }, 2);
+    check(ubuf, "v10l", (uint8_t []){ 0, 2 }, 2);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "y10l", (uint8_t []){ 0, 0 }, 2);
+    check(ubuf, "u10l", (uint8_t []){ 0, 2 }, 2);
+    check(ubuf, "v10l", (uint8_t []){ 0, 2 }, 2);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* v210 */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr,
+        "u10y10v10y10u10y10v10y10u10y10v10y10", 1, 1, 16));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "u10y10v10y10u10y10v10y10u10y10v10y10",
+          (uint8_t []){ 0, 66, 0, 32, 16, 0, 8, 1 }, 8);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "u10y10v10y10u10y10v10y10u10y10v10y10",
+          (uint8_t []){ 0, 2, 0, 32, 0, 0, 8, 0 }, 8);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    umem_mgr_release(umem_mgr);
+    return 0;
+}


### PR DESCRIPTION
Use ubuf_pic_plane_set_color with a chroma-specific color pattern.
Improve speed of ubuf_pic_plane_set_color for patterns larger than 1
byte by copying whole lines instead of a few bytes at a time, leading
to a 12x speed increase for yuv420p10le.