### PR TITLE
upipe: fix sub manager initialization

### DIFF
--- a/include/upipe/upipe.h
+++ b/include/upipe/upipe.h
@@ -224,6 +224,25 @@ struct upipe_mgr {
     int (*upipe_mgr_control)(struct upipe_mgr *, int, va_list);
 };
 
+/** @This initializes a upipe manager structure with default values.
+ *
+ * @param mgr pointer to upipe manager
+ */
+static inline void upipe_mgr_init(struct upipe_mgr *mgr)
+{
+    if (mgr) {
+        mgr->refcount = NULL;
+        mgr->signature = 0;
+        mgr->upipe_err_str = NULL;
+        mgr->upipe_command_str = NULL;
+        mgr->upipe_event_str = NULL;
+        mgr->upipe_alloc = NULL;
+        mgr->upipe_input = NULL;
+        mgr->upipe_control = NULL;
+        mgr->upipe_mgr_control = NULL;
+    }
+}
+
 /** @This increments the reference count of a upipe manager.
  *
  * @param mgr pointer to upipe manager

--- a/include/upipe/upipe_helper_subpipe.h
+++ b/include/upipe/upipe_helper_subpipe.h
@@ -302,6 +302,7 @@ static void STRUCTURE_SUB##_clean_sub(struct upipe *upipe)                  \
 static void STRUCTURE##_init_sub_##SUB##s(struct upipe *upipe)              \
 {                                                                           \
     struct STRUCTURE *s = STRUCTURE##_from_upipe(upipe);                    \
+    upipe_mgr_init(&s->MGR);                                                \
     ulist_init(&s->ULIST);                                                  \
 }                                                                           \
 /** @This returns the subpipe manager of a super-pipe.                      \

--- a/lib/upipe-av/upipe_avfilter.c
+++ b/lib/upipe-av/upipe_avfilter.c
@@ -2760,8 +2760,8 @@ static struct upipe *upipe_avfilt_alloc(struct upipe_mgr *mgr,
     upipe_avfilt_init_urefcount(upipe);
     upipe_avfilt_init_output(upipe);
     upipe_avfilt_init_flow_def(upipe);
-    upipe_avfilt_init_sub_mgr(upipe);
     upipe_avfilt_init_sub_subs(upipe);
+    upipe_avfilt_init_sub_mgr(upipe);
     upipe_avfilt_init_sync(upipe);
 
     struct upipe_avfilt *upipe_avfilt = upipe_avfilt_from_upipe(upipe);

--- a/lib/upipe-av/upipe_avformat_sink.c
+++ b/lib/upipe-av/upipe_avformat_sink.c
@@ -723,8 +723,8 @@ static struct upipe *upipe_avfsink_alloc(struct upipe_mgr *mgr,
 
     struct upipe_avfsink *upipe_avfsink = upipe_avfsink_from_upipe(upipe);
     upipe_avfsink_init_urefcount(upipe);
-    upipe_avfsink_init_sub_mgr(upipe);
     upipe_avfsink_init_sub_subs(upipe);
+    upipe_avfsink_init_sub_mgr(upipe);
 
     upipe_avfsink->uri = NULL;
     upipe_avfsink->init_uri = NULL;

--- a/lib/upipe-av/upipe_avformat_source.c
+++ b/lib/upipe-av/upipe_avformat_source.c
@@ -455,13 +455,8 @@ static void upipe_avfsrc_init_sub_mgr(struct upipe *upipe)
     struct upipe_mgr *sub_mgr = &upipe_avfsrc->sub_mgr;
     sub_mgr->refcount = upipe_avfsrc_to_urefcount_real(upipe_avfsrc);
     sub_mgr->signature = UPIPE_AVFSRC_OUTPUT_SIGNATURE;
-    sub_mgr->upipe_err_str = NULL;
-    sub_mgr->upipe_command_str = NULL;
-    sub_mgr->upipe_event_str = NULL;
     sub_mgr->upipe_alloc = upipe_avfsrc_sub_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_avfsrc_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates an avfsrc pipe.
@@ -485,8 +480,8 @@ static struct upipe *upipe_avfsrc_alloc(struct upipe_mgr *mgr,
     urefcount_init(upipe_avfsrc_to_urefcount_real(upipe_avfsrc),
                    upipe_avfsrc_free);
     upipe_avfsrc_init_output(upipe);
-    upipe_avfsrc_init_sub_mgr(upipe);
     upipe_avfsrc_init_sub_subs(upipe);
+    upipe_avfsrc_init_sub_mgr(upipe);
     upipe_avfsrc_init_uref_mgr(upipe);
     upipe_avfsrc_init_upump_mgr(upipe);
     upipe_avfsrc_init_upump(upipe);

--- a/lib/upipe-blackmagic/upipe_blackmagic_sink.cpp
+++ b/lib/upipe-blackmagic/upipe_blackmagic_sink.cpp
@@ -1508,7 +1508,6 @@ static void upipe_bmd_sink_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_bmd_sink_sub_alloc;
     sub_mgr->upipe_input = upipe_bmd_sink_sub_input;
     sub_mgr->upipe_control = upipe_bmd_sink_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @This returns the Blackmagic hardware output time.

--- a/lib/upipe-blackmagic/upipe_blackmagic_source.cpp
+++ b/lib/upipe-blackmagic/upipe_blackmagic_source.cpp
@@ -652,12 +652,9 @@ static void upipe_bmd_src_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_bmd_src *upipe_bmd_src = upipe_bmd_src_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_bmd_src->sub_mgr;
-    sub_mgr->refcount = NULL;
+    upipe_mgr_init(sub_mgr);
     sub_mgr->signature = UPIPE_BMD_SRC_OUTPUT_SIGNATURE;
-    sub_mgr->upipe_alloc = NULL;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_bmd_src_output_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a bmd source pipe.

--- a/lib/upipe-filters/upipe_filter_vanc.c
+++ b/lib/upipe-filters/upipe_filter_vanc.c
@@ -339,12 +339,9 @@ static void upipe_vanc_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_vanc *upipe_vanc = upipe_vanc_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_vanc->sub_mgr;
-    sub_mgr->refcount = NULL;
+    upipe_mgr_init(sub_mgr);
     sub_mgr->signature = UPIPE_VANC_OUTPUT_SIGNATURE;
-    sub_mgr->upipe_alloc = NULL;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_vanc_output_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a vanc pipe.

--- a/lib/upipe-filters/upipe_rtcp_fb_receiver.c
+++ b/lib/upipe-filters/upipe_rtcp_fb_receiver.c
@@ -527,7 +527,6 @@ static void upipe_rtcpfb_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_rtcpfb_input_alloc;
     sub_mgr->upipe_input = upipe_rtcpfb_input_sub;
     sub_mgr->upipe_control = upipe_rtcpfb_input_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a rtcpfb pipe.
@@ -553,8 +552,8 @@ static struct upipe *upipe_rtcpfb_alloc(struct upipe_mgr *mgr,
     upipe_rtcpfb_init_upump_timer(upipe);
     upipe_rtcpfb_init_uclock(upipe);
     upipe_rtcpfb_init_output(upipe);
-    upipe_rtcpfb_init_sub_mgr(upipe);
     upipe_rtcpfb_init_sub_outputs(upipe);
+    upipe_rtcpfb_init_sub_mgr(upipe);
     upipe_rtcpfb_init_ubuf_mgr(upipe);
     upipe_rtcpfb_init_uref_mgr(upipe);
     ulist_init(&upipe_rtcpfb->queue);

--- a/lib/upipe-filters/upipe_rtp_feedback.c
+++ b/lib/upipe-filters/upipe_rtp_feedback.c
@@ -641,7 +641,6 @@ static void upipe_rtpfb_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_rtpfb_output_alloc;
     sub_mgr->upipe_input = upipe_rtpfb_output_input;
     sub_mgr->upipe_control = upipe_rtpfb_output_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 static void upipe_rtpfb_output_send_rr_xr(struct upipe *upipe)
@@ -751,8 +750,8 @@ static struct upipe *upipe_rtpfb_alloc(struct upipe_mgr *mgr,
     upipe_rtpfb_init_urefcount(upipe);
     upipe_rtpfb_init_urefcount_real(upipe);
     upipe_rtpfb_init_output(upipe);
-    upipe_rtpfb_init_sub_mgr(upipe);
     upipe_rtpfb_init_sub_outputs(upipe);
+    upipe_rtpfb_init_sub_mgr(upipe);
     upipe_rtpfb->expected_seqnum = UINT_MAX;
     upipe_rtpfb->flow_def_input = NULL;
     upipe_rtpfb_init_upump_mgr(upipe);

--- a/lib/upipe-hls/upipe_hls_master.c
+++ b/lib/upipe-hls/upipe_hls_master.c
@@ -212,7 +212,6 @@ static void upipe_hls_master_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_hls_master *upipe_hls_master =
         upipe_hls_master_from_upipe(upipe);
-    memset(&upipe_hls_master->sub_mgr, 0, sizeof (upipe_hls_master->sub_mgr));
     upipe_hls_master->sub_mgr.refcount = &upipe_hls_master->urefcount;
     upipe_hls_master->sub_mgr.signature = UPIPE_HLS_MASTER_SUB_SIGNATURE;
     upipe_hls_master->sub_mgr.upipe_alloc = upipe_hls_master_sub_alloc;

--- a/lib/upipe-hls/upipe_hls_variant.c
+++ b/lib/upipe-hls/upipe_hls_variant.c
@@ -307,8 +307,6 @@ static void upipe_hls_variant_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_hls_variant *upipe_hls_variant =
         upipe_hls_variant_from_upipe(upipe);
-
-    memset(&upipe_hls_variant->sub_mgr, 0, sizeof (upipe_hls_variant->sub_mgr));
     upipe_hls_variant->sub_mgr.signature = UPIPE_HLS_VARIANT_SUB_SIGNATURE;
     upipe_hls_variant->sub_mgr.refcount = upipe->refcount;
     upipe_hls_variant->sub_mgr.upipe_alloc = upipe_hls_variant_sub_alloc;
@@ -335,8 +333,8 @@ static struct upipe *upipe_hls_variant_alloc(struct upipe_mgr *mgr,
         return NULL;
 
     upipe_hls_variant_init_urefcount(upipe);
-    upipe_hls_variant_init_sub_mgr(upipe);
     upipe_hls_variant_init_sub_pipes(upipe);
+    upipe_hls_variant_init_sub_mgr(upipe);
     upipe_hls_variant_init_upump_mgr(upipe);
     upipe_hls_variant_init_upump(upipe);
 

--- a/lib/upipe-hls/upipe_hls_void.c
+++ b/lib/upipe-hls/upipe_hls_void.c
@@ -508,7 +508,6 @@ static int probe_src(struct uprobe *uprobe, struct upipe *inner,
 static void upipe_hls_void_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_hls_void *upipe_hls_void = upipe_hls_void_from_upipe(upipe);
-    memset(&upipe_hls_void->sub_mgr, 0, sizeof (struct upipe_mgr));
     upipe_hls_void->sub_mgr.refcount = &upipe_hls_void->urefcount_real;
     upipe_hls_void->sub_mgr.signature = UPIPE_HLS_VOID_SUB_SIGNATURE;
     upipe_hls_void->sub_mgr.upipe_alloc = upipe_hls_void_sub_alloc;
@@ -541,8 +540,8 @@ static struct upipe *upipe_hls_void_alloc(struct upipe_mgr *mgr,
     upipe_hls_void_init_probe_aes_decrypt(upipe);
     upipe_hls_void_init_probe_demux_in(upipe);
     upipe_hls_void_init_probe_demux_out(upipe);
-    upipe_hls_void_init_sub_mgr(upipe);
     upipe_hls_void_init_sub_pipes(upipe);
+    upipe_hls_void_init_sub_mgr(upipe);
     upipe_hls_void_init_src(upipe);
     upipe_hls_void_init_playlist(upipe);
     upipe_hls_void_init_pmt(upipe);

--- a/lib/upipe-modules/upipe_audio_merge.c
+++ b/lib/upipe-modules/upipe_audio_merge.c
@@ -473,7 +473,6 @@ static void upipe_audio_merge_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_audio_merge_sub_alloc;
     sub_mgr->upipe_input = upipe_audio_merge_sub_input;
     sub_mgr->upipe_control = upipe_audio_merge_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates an audio_merge pipe.
@@ -501,8 +500,8 @@ static struct upipe *upipe_audio_merge_alloc(struct upipe_mgr *mgr,
     upipe_audio_merge_init_urefcount_real(upipe);
 
     upipe_audio_merge_init_output(upipe);
-    upipe_audio_merge_init_sub_mgr(upipe);
     upipe_audio_merge_init_sub_inputs(upipe);
+    upipe_audio_merge_init_sub_mgr(upipe);
     upipe_audio_merge_init_ubuf_mgr(upipe);
 
     upipe_audio_merge->sub_flow_def = NULL;

--- a/lib/upipe-modules/upipe_audio_split.c
+++ b/lib/upipe-modules/upipe_audio_split.c
@@ -383,9 +383,7 @@ static void upipe_audio_split_init_sub_mgr(struct upipe *upipe)
     sub_mgr->refcount = upipe_audio_split_to_urefcount_real(upipe_audio_split);
     sub_mgr->signature = UPIPE_AUDIO_SPLIT_OUTPUT_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_audio_split_sub_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_audio_split_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates an audio_split pipe.
@@ -410,8 +408,8 @@ static struct upipe *upipe_audio_split_alloc(struct upipe_mgr *mgr,
     upipe_audio_split_init_urefcount(upipe);
     urefcount_init(upipe_audio_split_to_urefcount_real(upipe_audio_split),
                    upipe_audio_split_free);
-    upipe_audio_split_init_sub_mgr(upipe);
     upipe_audio_split_init_sub_outputs(upipe);
+    upipe_audio_split_init_sub_mgr(upipe);
     upipe_audio_split->flow_def = NULL;
     upipe_throw_ready(upipe);
     return upipe;

--- a/lib/upipe-modules/upipe_audiocont.c
+++ b/lib/upipe-modules/upipe_audiocont.c
@@ -565,7 +565,6 @@ static void upipe_audiocont_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_audiocont_sub_alloc;
     sub_mgr->upipe_input = upipe_audiocont_sub_input;
     sub_mgr->upipe_control = upipe_audiocont_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a audiocont pipe.
@@ -602,8 +601,8 @@ static struct upipe *upipe_audiocont_alloc(struct upipe_mgr *mgr,
     upipe_audiocont_init_ubuf_mgr(upipe);
     upipe_audiocont_init_output(upipe);
     upipe_audiocont_init_flow_def_check(upipe);
-    upipe_audiocont_init_sub_mgr(upipe);
     upipe_audiocont_init_sub_subs(upipe);
+    upipe_audiocont_init_sub_mgr(upipe);
 
     upipe_audiocont->input_cur = NULL;
     upipe_audiocont->input_prev = NULL;

--- a/lib/upipe-modules/upipe_blit.c
+++ b/lib/upipe-modules/upipe_blit.c
@@ -852,13 +852,11 @@ static void upipe_blit_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_blit *upipe_blit = upipe_blit_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_blit->sub_mgr;
-    memset(sub_mgr, 0, sizeof (*sub_mgr));
     sub_mgr->refcount = upipe_blit_to_urefcount(upipe_blit);
     sub_mgr->signature = UPIPE_BLIT_SUB_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_blit_sub_alloc;
     sub_mgr->upipe_input = upipe_blit_sub_input;
     sub_mgr->upipe_control = upipe_blit_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a blit pipe.
@@ -880,8 +878,8 @@ static struct upipe *upipe_blit_alloc(struct upipe_mgr *mgr,
     struct upipe_blit *upipe_blit = upipe_blit_from_upipe(upipe);
     upipe_blit_init_urefcount(upipe);
     upipe_blit_init_output(upipe);
-    upipe_blit_init_sub_mgr(upipe);
     upipe_blit_init_sub_subs(upipe);
+    upipe_blit_init_sub_mgr(upipe);
     upipe_blit_init_upump_mgr(upipe);
     upipe_blit_init_idler(upipe);
     upipe_blit_init_flow_format(upipe);

--- a/lib/upipe-modules/upipe_dejitter.c
+++ b/lib/upipe-modules/upipe_dejitter.c
@@ -216,7 +216,6 @@ static void upipe_dejitter_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_dejitter_sub_alloc;
     sub_mgr->upipe_input = upipe_dejitter_sub_input;
     sub_mgr->upipe_control = upipe_dejitter_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a dejitter pipe.
@@ -238,8 +237,8 @@ static struct upipe *upipe_dejitter_alloc(struct upipe_mgr *mgr,
 
     struct upipe_dejitter *upipe_dejitter = upipe_dejitter_from_upipe(upipe);
     upipe_dejitter_init_urefcount(upipe);
-    upipe_dejitter_init_sub_mgr(upipe);
     upipe_dejitter_init_sub_subs(upipe);
+    upipe_dejitter_init_sub_mgr(upipe);
     upipe_dejitter_init_output(upipe);
     upipe_dejitter->inited = false;
     upipe_throw_ready(upipe);

--- a/lib/upipe-modules/upipe_dup.c
+++ b/lib/upipe-modules/upipe_dup.c
@@ -187,13 +187,10 @@ static void upipe_dup_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_dup *upipe_dup = upipe_dup_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_dup->sub_mgr;
-    memset(sub_mgr, 0, sizeof (*sub_mgr));
     sub_mgr->refcount = upipe_dup_to_urefcount_real(upipe_dup);
     sub_mgr->signature = UPIPE_DUP_OUTPUT_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_dup_output_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_dup_output_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a dup pipe.
@@ -215,8 +212,8 @@ static struct upipe *upipe_dup_alloc(struct upipe_mgr *mgr,
     struct upipe_dup *upipe_dup = upipe_dup_from_upipe(upipe);
     upipe_dup_init_urefcount(upipe);
     upipe_dup_init_urefcount_real(upipe);
-    upipe_dup_init_sub_mgr(upipe);
     upipe_dup_init_sub_outputs(upipe);
+    upipe_dup_init_sub_mgr(upipe);
     upipe_dup_init_output(upipe);
     upipe_dup->flow_def = NULL;
     upipe_throw_ready(upipe);

--- a/lib/upipe-modules/upipe_even.c
+++ b/lib/upipe-modules/upipe_even.c
@@ -379,7 +379,6 @@ static void upipe_even_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_even_sub_alloc;
     sub_mgr->upipe_input = upipe_even_sub_input;
     sub_mgr->upipe_control = upipe_even_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a even pipe.
@@ -398,8 +397,8 @@ static struct upipe *upipe_even_alloc(struct upipe_mgr *mgr,
     if (unlikely(upipe == NULL))
         return NULL;
     upipe_even_init_urefcount(upipe);
-    upipe_even_init_sub_mgr(upipe);
     upipe_even_init_sub_subs(upipe);
+    upipe_even_init_sub_mgr(upipe);
     struct upipe_even *upipe_even = upipe_even_from_upipe(upipe);
     upipe_even->first_date = UINT64_MAX;
     upipe_even->preroll = true;

--- a/lib/upipe-modules/upipe_graph.c
+++ b/lib/upipe-modules/upipe_graph.c
@@ -339,8 +339,6 @@ static void upipe_graph_init_mgr(struct upipe *upipe)
     struct upipe_mgr *mgr = upipe_graph_to_mgr(upipe_graph);
     mgr->refcount = upipe_graph_to_urefcount_real(upipe_graph);
     mgr->signature = UPIPE_GRAPH_SUB_SIGNATURE;
-    mgr->upipe_err_str = NULL;
-    mgr->upipe_command_str = NULL;
     mgr->upipe_alloc = upipe_graph_input_alloc;
     mgr->upipe_input = upipe_graph_input_input;
     mgr->upipe_control = upipe_graph_input_control;

--- a/lib/upipe-modules/upipe_play.c
+++ b/lib/upipe-modules/upipe_play.c
@@ -258,7 +258,6 @@ static void upipe_play_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_play_sub_alloc;
     sub_mgr->upipe_input = upipe_play_sub_output;
     sub_mgr->upipe_control = upipe_play_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a play pipe.
@@ -277,8 +276,8 @@ static struct upipe *upipe_play_alloc(struct upipe_mgr *mgr,
     if (unlikely(upipe == NULL))
         return NULL;
     upipe_play_init_urefcount(upipe);
-    upipe_play_init_sub_mgr(upipe);
     upipe_play_init_sub_subs(upipe);
+    upipe_play_init_sub_mgr(upipe);
     struct upipe_play *upipe_play = upipe_play_from_upipe(upipe);
     upipe_play->input_latency = 0;
     upipe_play->sink_latency = upipe_play->latency = DEFAULT_OUTPUT_LATENCY;

--- a/lib/upipe-modules/upipe_rtp_demux.c
+++ b/lib/upipe-modules/upipe_rtp_demux.c
@@ -424,13 +424,9 @@ static void upipe_rtp_demux_init_sub_mgr(struct upipe *upipe)
     struct upipe_mgr *sub_mgr = &demux->sub_mgr;
     sub_mgr->refcount = upipe->refcount;
     sub_mgr->signature = UPIPE_RTP_DEMUX_SUB_SIGNATURE;
-    sub_mgr->upipe_err_str = NULL;
-    sub_mgr->upipe_command_str = NULL;
-    sub_mgr->upipe_event_str = NULL;
     sub_mgr->upipe_alloc = upipe_rtp_demux_sub_alloc;
     sub_mgr->upipe_input = upipe_rtp_demux_sub_bin_input;
     sub_mgr->upipe_control = upipe_rtp_demux_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This handles clock references coming from clock_ref events.
@@ -514,8 +510,8 @@ static struct upipe *upipe_rtp_demux_alloc(struct upipe_mgr *mgr,
         return NULL;
     struct upipe_rtp_demux *demux = upipe_rtp_demux_from_upipe(upipe);
     upipe_rtp_demux_init_urefcount(upipe);
-    upipe_rtp_demux_init_sub_mgr(upipe);
     upipe_rtp_demux_init_sub_subs(upipe);
+    upipe_rtp_demux_init_sub_mgr(upipe);
     demux->orig_prog_offset = 0;
     demux->highest_date_prog = UINT32_MAX;
     demux->last_cr = UINT32_MAX;

--- a/lib/upipe-modules/upipe_rtp_reorder.c
+++ b/lib/upipe-modules/upipe_rtp_reorder.c
@@ -429,7 +429,6 @@ static void upipe_rtpr_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_rtpr_sub_alloc;
     sub_mgr->upipe_input = upipe_rtpr_sub_input;
     sub_mgr->upipe_control = upipe_rtpr_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 static void upipe_rtpr_clean_queue(struct upipe *upipe)
@@ -470,8 +469,8 @@ static struct upipe *upipe_rtpr_alloc(struct upipe_mgr *mgr,
     upipe_rtpr_init_upump(upipe);
     upipe_rtpr_init_uclock(upipe);
     upipe_rtpr_init_output(upipe);
-    upipe_rtpr_init_sub_mgr(upipe);
     upipe_rtpr_init_sub_inputs(upipe);
+    upipe_rtpr_init_sub_mgr(upipe);
 
     ulist_init(&upipe_rtpr->queue);
 

--- a/lib/upipe-modules/upipe_stream_switcher.c
+++ b/lib/upipe-modules/upipe_stream_switcher.c
@@ -529,8 +529,6 @@ static void upipe_stream_switcher_init_sub_mgr(struct upipe *upipe)
         upipe_stream_switcher_from_upipe(upipe);
     struct upipe_mgr *sub_mgr =
         upipe_stream_switcher_to_sub_mgr(upipe_stream_switcher);
-
-    memset(sub_mgr, 0, sizeof (*sub_mgr));
     sub_mgr->signature = UPIPE_STREAM_SWITCHER_SUB_SIGNATURE;
     sub_mgr->upipe_event_str = uprobe_stream_switcher_sub_event_str;
     sub_mgr->upipe_alloc = upipe_stream_switcher_input_alloc;

--- a/lib/upipe-modules/upipe_subpic_schedule.c
+++ b/lib/upipe-modules/upipe_subpic_schedule.c
@@ -228,7 +228,6 @@ static void upipe_subpic_schedule_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_subpic_schedule_sub_alloc;
     sub_mgr->upipe_input = upipe_subpic_schedule_sub_input;
     sub_mgr->upipe_control = upipe_subpic_schedule_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This frees all resources allocated.

--- a/lib/upipe-modules/upipe_sync.c
+++ b/lib/upipe-modules/upipe_sync.c
@@ -901,7 +901,6 @@ static void upipe_sync_init_sub_mgr(struct upipe *upipe)
 {
     struct upipe_sync *upipe_sync = upipe_sync_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_sync->sub_mgr;
-    memset(sub_mgr, 0, sizeof(*sub_mgr));
     sub_mgr->refcount = upipe->refcount;
     sub_mgr->signature = UPIPE_SYNC_SUB_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_sync_sub_alloc;

--- a/lib/upipe-modules/upipe_trickplay.c
+++ b/lib/upipe-modules/upipe_trickplay.c
@@ -324,7 +324,6 @@ static void upipe_trickp_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_trickp_sub_alloc;
     sub_mgr->upipe_input = upipe_trickp_sub_input;
     sub_mgr->upipe_control = upipe_trickp_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a trickp pipe.
@@ -343,8 +342,8 @@ static struct upipe *upipe_trickp_alloc(struct upipe_mgr *mgr,
     if (unlikely(upipe == NULL))
         return NULL;
     upipe_trickp_init_urefcount(upipe);
-    upipe_trickp_init_sub_mgr(upipe);
     upipe_trickp_init_sub_subs(upipe);
+    upipe_trickp_init_sub_mgr(upipe);
     upipe_trickp_init_uclock(upipe);
     struct upipe_trickp *upipe_trickp = upipe_trickp_from_upipe(upipe);
     upipe_trickp->systime_offset = 0;

--- a/lib/upipe-modules/upipe_videocont.c
+++ b/lib/upipe-modules/upipe_videocont.c
@@ -370,7 +370,6 @@ static void upipe_videocont_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_videocont_sub_alloc;
     sub_mgr->upipe_input = upipe_videocont_sub_input;
     sub_mgr->upipe_control = upipe_videocont_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a videocont pipe.
@@ -392,8 +391,8 @@ static struct upipe *upipe_videocont_alloc(struct upipe_mgr *mgr,
 
     upipe_videocont_init_urefcount(upipe);
     upipe_videocont_init_output(upipe);
-    upipe_videocont_init_sub_mgr(upipe);
     upipe_videocont_init_sub_subs(upipe);
+    upipe_videocont_init_sub_mgr(upipe);
 
     struct upipe_videocont *upipe_videocont = upipe_videocont_from_upipe(upipe);
     upipe_videocont->input_cur = NULL;

--- a/lib/upipe-ts/upipe_rtp_fec.c
+++ b/lib/upipe-ts/upipe_rtp_fec.c
@@ -920,12 +920,11 @@ static void upipe_rtp_fec_init_sub_mgr(struct upipe *upipe)
     struct upipe_rtp_fec *upipe_rtp_fec = upipe_rtp_fec_from_upipe(upipe);
     struct upipe_mgr *sub_mgr = &upipe_rtp_fec->sub_mgr;
 
+    upipe_mgr_init(sub_mgr);
     sub_mgr->refcount = upipe_rtp_fec_to_urefcount(upipe_rtp_fec);
     sub_mgr->signature = UPIPE_RTP_FEC_INPUT_SIGNATURE;
-    sub_mgr->upipe_alloc = NULL;
     sub_mgr->upipe_input = upipe_rtp_fec_sub_input;
     sub_mgr->upipe_control = upipe_rtp_fec_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a rtp-fec pipe.

--- a/lib/upipe-ts/upipe_ts_demux.c
+++ b/lib/upipe-ts/upipe_ts_demux.c
@@ -1176,13 +1176,8 @@ static void upipe_ts_demux_program_init_output_mgr(struct upipe *upipe)
     struct upipe_mgr *output_mgr = &program->output_mgr;
     output_mgr->refcount = upipe_ts_demux_program_to_urefcount_real(program);
     output_mgr->signature = UPIPE_TS_DEMUX_OUTPUT_SIGNATURE;
-    output_mgr->upipe_err_str = NULL;
-    output_mgr->upipe_command_str = NULL;
-    output_mgr->upipe_event_str = NULL;
     output_mgr->upipe_alloc = upipe_ts_demux_output_alloc;
-    output_mgr->upipe_input = NULL;
     output_mgr->upipe_control = upipe_ts_demux_output_control;
-    output_mgr->upipe_mgr_control = NULL;
 }
 
 
@@ -2004,8 +1999,8 @@ static struct upipe *upipe_ts_demux_program_alloc(struct upipe_mgr *mgr,
     upipe_ts_demux_program_init_urefcount(upipe);
     urefcount_init(upipe_ts_demux_program_to_urefcount_real(upipe_ts_demux_program), upipe_ts_demux_program_free);
     upipe_ts_demux_program_init_output(upipe);
-    upipe_ts_demux_program_init_output_mgr(upipe);
     upipe_ts_demux_program_init_sub_outputs(upipe);
+    upipe_ts_demux_program_init_output_mgr(upipe);
     upipe_ts_demux_program->flow_def_input = flow_def;
     upipe_ts_demux_program->program = 0;
     upipe_ts_demux_program->pmt_rap = 0;
@@ -2275,13 +2270,8 @@ static void upipe_ts_demux_init_program_mgr(struct upipe *upipe)
     struct upipe_mgr *program_mgr = &upipe_ts_demux->program_mgr;
     program_mgr->refcount = upipe_ts_demux_to_urefcount_real(upipe_ts_demux);
     program_mgr->signature = UPIPE_TS_DEMUX_PROGRAM_SIGNATURE;
-    program_mgr->upipe_err_str = NULL;
-    program_mgr->upipe_command_str = NULL;
-    program_mgr->upipe_event_str = NULL;
     program_mgr->upipe_alloc = upipe_ts_demux_program_alloc;
-    program_mgr->upipe_input = NULL;
     program_mgr->upipe_control = upipe_ts_demux_program_control;
-    program_mgr->upipe_mgr_control = NULL;
 }
 
 
@@ -3177,8 +3167,8 @@ static struct upipe *upipe_ts_demux_alloc(struct upipe_mgr *mgr,
     upipe_ts_demux_init_bin_input(upipe);
     upipe_ts_demux_init_output(upipe);
     upipe_ts_demux_init_uref_mgr(upipe);
-    upipe_ts_demux_init_program_mgr(upipe);
     upipe_ts_demux_init_sub_programs(upipe);
+    upipe_ts_demux_init_program_mgr(upipe);
 
     upipe_ts_demux_init_sync(upipe);
     upipe_ts_demux->input = upipe_ts_demux->split = upipe_ts_demux->setrap =

--- a/lib/upipe-ts/upipe_ts_emm_decoder.c
+++ b/lib/upipe-ts/upipe_ts_emm_decoder.c
@@ -1307,5 +1307,4 @@ static void upipe_ts_emmd_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_ts_emmd_ecm_alloc;
     sub_mgr->upipe_input = upipe_ts_emmd_ecm_input;
     sub_mgr->upipe_control = upipe_ts_emmd_ecm_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }

--- a/lib/upipe-ts/upipe_ts_mux.c
+++ b/lib/upipe-ts/upipe_ts_mux.c
@@ -1736,7 +1736,6 @@ static void upipe_ts_mux_program_init_input_mgr(struct upipe *upipe)
     input_mgr->upipe_alloc = upipe_ts_mux_input_alloc;
     input_mgr->upipe_input = upipe_ts_mux_input_input;
     input_mgr->upipe_control = upipe_ts_mux_input_control;
-    input_mgr->upipe_mgr_control = NULL;
 }
 
 
@@ -1824,8 +1823,8 @@ static struct upipe *upipe_ts_mux_program_alloc(struct upipe_mgr *mgr,
     urefcount_init(upipe_ts_mux_program_to_urefcount_real(upipe_ts_mux_program),
                    upipe_ts_mux_program_free);
     upipe_ts_mux_program_init_bin_input(upipe);
-    upipe_ts_mux_program_init_input_mgr(upipe);
     upipe_ts_mux_program_init_sub_inputs(upipe);
+    upipe_ts_mux_program_init_input_mgr(upipe);
     upipe_ts_mux_program->flow_def_input = NULL;
     upipe_ts_mux_program->psi_pid_pmt = NULL;
     upipe_ts_mux_program->sig_service = NULL;
@@ -2474,9 +2473,7 @@ static void upipe_ts_mux_init_program_mgr(struct upipe *upipe)
     program_mgr->refcount = upipe_ts_mux_to_urefcount(upipe_ts_mux);
     program_mgr->signature = UPIPE_TS_MUX_PROGRAM_SIGNATURE;
     program_mgr->upipe_alloc = upipe_ts_mux_program_alloc;
-    program_mgr->upipe_input = NULL;
     program_mgr->upipe_control = upipe_ts_mux_program_control;
-    program_mgr->upipe_mgr_control = NULL;
 }
 
 
@@ -2594,8 +2591,8 @@ static struct upipe *upipe_ts_mux_alloc(struct upipe_mgr *mgr,
     upipe_ts_mux_init_uclock(upipe);
     upipe_ts_mux_init_bin_input(upipe);
     upipe_ts_mux_init_inner_sink(upipe);
-    upipe_ts_mux_init_program_mgr(upipe);
     upipe_ts_mux_init_sub_programs(upipe);
+    upipe_ts_mux_init_program_mgr(upipe);
 
     upipe_ts_mux->live = false;
     upipe_ts_mux->psi_pid_pat = NULL;

--- a/lib/upipe-ts/upipe_ts_psi_generator.c
+++ b/lib/upipe-ts/upipe_ts_psi_generator.c
@@ -980,9 +980,7 @@ static void upipe_ts_psig_program_init_flow_mgr(struct upipe *upipe)
         upipe_ts_psig_program_to_urefcount(upipe_ts_psig_program);
     flow_mgr->signature = UPIPE_TS_PSIG_FLOW_SIGNATURE;
     flow_mgr->upipe_alloc = upipe_ts_psig_flow_alloc;
-    flow_mgr->upipe_input = NULL;
     flow_mgr->upipe_control = upipe_ts_psig_flow_control;
-    flow_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a program of a ts_psig pipe.
@@ -1007,8 +1005,8 @@ static struct upipe *upipe_ts_psig_program_alloc(struct upipe_mgr *mgr,
         upipe_ts_psig_program_from_upipe(upipe);
     upipe_ts_psig_program_init_urefcount(upipe);
     upipe_ts_psig_program_init_output(upipe);
-    upipe_ts_psig_program_init_flow_mgr(upipe);
     upipe_ts_psig_program_init_sub_flows(upipe);
+    upipe_ts_psig_program_init_flow_mgr(upipe);
     upipe_ts_psig_program_init_sub(upipe);
     upipe_ts_psig_program->flow_def = NULL;
     upipe_ts_psig_program->frozen = false;
@@ -1524,7 +1522,6 @@ static void upipe_ts_psig_init_program_mgr(struct upipe *upipe)
     program_mgr->refcount = upipe_ts_psig_to_urefcount(upipe_ts_psig);
     program_mgr->signature = UPIPE_TS_PSIG_PROGRAM_SIGNATURE;
     program_mgr->upipe_alloc = upipe_ts_psig_program_alloc;
-    program_mgr->upipe_input = NULL;
     program_mgr->upipe_control = upipe_ts_psig_program_control;
 }
 
@@ -1550,8 +1547,8 @@ static struct upipe *upipe_ts_psig_alloc(struct upipe_mgr *mgr,
     upipe_ts_psig_init_uref_mgr(upipe);
     upipe_ts_psig_init_ubuf_mgr(upipe);
     upipe_ts_psig_init_output(upipe);
-    upipe_ts_psig_init_program_mgr(upipe);
     upipe_ts_psig_init_sub_programs(upipe);
+    upipe_ts_psig_init_program_mgr(upipe);
     upipe_ts_psig->flow_def = NULL;
     upipe_ts_psig->frozen = false;
     upipe_ts_psig->cr_sys_status = UINT64_MAX;

--- a/lib/upipe-ts/upipe_ts_psi_join.c
+++ b/lib/upipe-ts/upipe_ts_psi_join.c
@@ -244,7 +244,6 @@ static void upipe_ts_psi_join_init_sub_mgr(struct upipe *upipe)
     sub_mgr->upipe_alloc = upipe_ts_psi_join_sub_alloc;
     sub_mgr->upipe_input = upipe_ts_psi_join_sub_input;
     sub_mgr->upipe_control = upipe_ts_psi_join_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a ts_psi_join pipe.
@@ -267,8 +266,8 @@ static struct upipe *upipe_ts_psi_join_alloc(struct upipe_mgr *mgr,
 
     upipe_ts_psi_join_init_urefcount(upipe);
     upipe_ts_psi_join_init_output(upipe);
-    upipe_ts_psi_join_init_sub_mgr(upipe);
     upipe_ts_psi_join_init_sub_subs(upipe);
+    upipe_ts_psi_join_init_sub_mgr(upipe);
 
     upipe_throw_ready(upipe);
     upipe_ts_psi_join_store_flow_def(upipe, flow_def);

--- a/lib/upipe-ts/upipe_ts_psi_split.c
+++ b/lib/upipe-ts/upipe_ts_psi_split.c
@@ -185,9 +185,7 @@ static void upipe_ts_psi_split_init_sub_mgr(struct upipe *upipe)
         upipe_ts_psi_split_to_urefcount_real(upipe_ts_psi_split);
     sub_mgr->signature = UPIPE_TS_PSI_SPLIT_OUTPUT_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_ts_psi_split_sub_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_ts_psi_split_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a ts_psi_split pipe.
@@ -211,8 +209,8 @@ static struct upipe *upipe_ts_psi_split_alloc(struct upipe_mgr *mgr,
     upipe_ts_psi_split_init_urefcount(upipe);
     urefcount_init(upipe_ts_psi_split_to_urefcount_real(upipe_ts_psi_split),
                    upipe_ts_psi_split_free);
-    upipe_ts_psi_split_init_sub_mgr(upipe);
     upipe_ts_psi_split_init_sub_subs(upipe);
+    upipe_ts_psi_split_init_sub_mgr(upipe);
     upipe_throw_ready(upipe);
     return upipe;
 }

--- a/lib/upipe-ts/upipe_ts_scte104_decoder.c
+++ b/lib/upipe-ts/upipe_ts_scte104_decoder.c
@@ -298,9 +298,7 @@ static void upipe_ts_scte104d_init_sub_mgr(struct upipe *upipe)
         upipe_ts_scte104d_to_urefcount_real(upipe_ts_scte104d);
     sub_mgr->signature = UPIPE_TS_SCTE104D_OUTPUT_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_ts_scte104d_sub_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_ts_scte104d_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a ts_scte104d pipe.
@@ -326,8 +324,8 @@ static struct upipe *upipe_ts_scte104d_alloc(struct upipe_mgr *mgr,
     urefcount_init(upipe_ts_scte104d_to_urefcount_real(upipe_ts_scte104d),
                    upipe_ts_scte104d_free);
     upipe_ts_scte104d_init_ubuf_mgr(upipe);
-    upipe_ts_scte104d_init_sub_mgr(upipe);
     upipe_ts_scte104d_init_sub_subs(upipe);
+    upipe_ts_scte104d_init_sub_mgr(upipe);
     upipe_ts_scte104d->flow_def = NULL;
 
     for (int i = 0; i <= UINT8_MAX; i++)

--- a/lib/upipe-ts/upipe_ts_si_generator.c
+++ b/lib/upipe-ts/upipe_ts_si_generator.c
@@ -879,7 +879,6 @@ static void upipe_ts_sig_init_service_mgr(struct upipe *upipe)
     service_mgr->refcount = upipe_ts_sig_to_urefcount(upipe_ts_sig);
     service_mgr->signature = UPIPE_TS_SIG_SERVICE_SIGNATURE;
     service_mgr->upipe_alloc = upipe_ts_sig_service_alloc;
-    service_mgr->upipe_input = NULL;
     service_mgr->upipe_control = upipe_ts_sig_service_control;
 }
 
@@ -998,8 +997,8 @@ static struct upipe *_upipe_ts_sig_alloc(struct upipe_mgr *mgr,
     upipe_ts_sig_init_ubuf_mgr(upipe);
     upipe_ts_sig_init_uclock(upipe);
     upipe_ts_sig_init_output(upipe);
-    upipe_ts_sig_init_service_mgr(upipe);
     upipe_ts_sig_init_sub_services(upipe);
+    upipe_ts_sig_init_service_mgr(upipe);
     upipe_ts_sig_init_output_mgr(upipe);
     upipe_ts_sig_init_dvb_string(upipe);
     upipe_ts_sig_store_flow_def(upipe, NULL);

--- a/lib/upipe-ts/upipe_ts_split.c
+++ b/lib/upipe-ts/upipe_ts_split.c
@@ -227,9 +227,7 @@ static void upipe_ts_split_init_sub_mgr(struct upipe *upipe)
     sub_mgr->refcount = upipe_ts_split_to_urefcount_real(upipe_ts_split);
     sub_mgr->signature = UPIPE_TS_SPLIT_OUTPUT_SIGNATURE;
     sub_mgr->upipe_alloc = upipe_ts_split_sub_alloc;
-    sub_mgr->upipe_input = NULL;
     sub_mgr->upipe_control = upipe_ts_split_sub_control;
-    sub_mgr->upipe_mgr_control = NULL;
 }
 
 /** @internal @This allocates a ts_split pipe.
@@ -253,8 +251,8 @@ static struct upipe *upipe_ts_split_alloc(struct upipe_mgr *mgr,
     upipe_ts_split_init_urefcount(upipe);
     urefcount_init(upipe_ts_split_to_urefcount_real(upipe_ts_split),
                    upipe_ts_split_free);
-    upipe_ts_split_init_sub_mgr(upipe);
     upipe_ts_split_init_sub_subs(upipe);
+    upipe_ts_split_init_sub_mgr(upipe);
 
     int i;
     for (i = 0; i < MAX_PIDS; i++) {


### PR DESCRIPTION
Make sure all the sub pipe manager structure is initialized to prevent
use of uninitialized memory.