### PR TITLE
10-bit alpha blend support for upipe_blit

### DIFF
--- a/include/upipe-av/upipe_av_pixfmt.h
+++ b/include/upipe-av/upipe_av_pixfmt.h
@@ -77,6 +77,12 @@ upipe_av_pixfmt_to_format(enum AVPixelFormat pix_fmt)
             return &uref_pic_flow_format_yuyv422;
         case AV_PIX_FMT_UYVY422:
             return &uref_pic_flow_format_uyvy422;
+        case AV_PIX_FMT_YUVA420P10LE:
+            return &uref_pic_flow_format_yuva420p10le;
+        case AV_PIX_FMT_YUVA422P10LE:
+            return &uref_pic_flow_format_yuva422p10le;
+        case AV_PIX_FMT_YUVA444P10LE:
+            return &uref_pic_flow_format_yuva444p10le;
         case AV_PIX_FMT_YUV420P10LE:
             return &uref_pic_flow_format_yuv420p10le;
         case AV_PIX_FMT_YUV420P10BE:
@@ -200,6 +206,9 @@ static inline enum AVPixelFormat
         AV_PIX_FMT_YUVJ444P,
         AV_PIX_FMT_YUYV422,
         AV_PIX_FMT_UYVY422,
+        AV_PIX_FMT_YUVA420P10LE,
+        AV_PIX_FMT_YUVA422P10LE,
+        AV_PIX_FMT_YUVA444P10LE,
         AV_PIX_FMT_YUV420P10LE,
         AV_PIX_FMT_YUV420P10BE,
         AV_PIX_FMT_YUV420P12LE,

--- a/include/upipe-modules/upipe_blit.h
+++ b/include/upipe-modules/upipe_blit.h
@@ -79,14 +79,14 @@ enum upipe_blit_sub_command {
      * will be blitted (struct urational, struct urational,
      * struct urational, struct urational) */
     UPIPE_BLIT_SUB_SET_MARGIN,
-    /** gets the alpha channel multiplier (uint8_t *) */
+    /** gets the alpha channel multiplier (int *) */
     UPIPE_BLIT_SUB_GET_ALPHA,
-    /** sets the alpha channel multiplier (uint8_t) */
+    /** sets the alpha channel multiplier (int) */
     UPIPE_BLIT_SUB_SET_ALPHA,
-    /** gets the method for alpha blending (uint8_t *)
+    /** gets the method for alpha blending (int *)
      * @see ubuf_pic_blit */
     UPIPE_BLIT_SUB_GET_ALPHA_THRESHOLD,
-    /** sets the method for alpha blending (uint8_t)
+    /** sets the method for alpha blending (int)
      * @see ubuf_pic_blit */
     UPIPE_BLIT_SUB_SET_ALPHA_THRESHOLD,
     /** gets the z-index (int *) */
@@ -173,7 +173,7 @@ static inline int upipe_blit_sub_set_margin(struct upipe *upipe,
  * @return an error code
  */
 static inline int upipe_blit_sub_get_alpha(struct upipe *upipe,
-        uint8_t *alpha_p)
+        int *alpha_p)
 {
     return upipe_control(upipe, UPIPE_BLIT_SUB_GET_ALPHA,
                          UPIPE_BLIT_SUB_SIGNATURE, alpha_p);
@@ -186,10 +186,10 @@ static inline int upipe_blit_sub_get_alpha(struct upipe *upipe,
  * @return an error code
  */
 static inline int upipe_blit_sub_set_alpha(struct upipe *upipe,
-        uint8_t alpha)
+        int alpha)
 {
     return upipe_control(upipe, UPIPE_BLIT_SUB_SET_ALPHA,
-                         UPIPE_BLIT_SUB_SIGNATURE, (unsigned)alpha);
+                         UPIPE_BLIT_SUB_SIGNATURE, alpha);
 }
 
 /** @This gets the method for alpha blending for this subpipe.
@@ -200,7 +200,7 @@ static inline int upipe_blit_sub_set_alpha(struct upipe *upipe,
  * @return an error code
  */
 static inline int upipe_blit_sub_get_alpha_threshold(struct upipe *upipe,
-        uint8_t *threshold_p)
+        int *threshold_p)
 {
     return upipe_control(upipe, UPIPE_BLIT_SUB_GET_ALPHA_THRESHOLD,
                          UPIPE_BLIT_SUB_SIGNATURE, threshold_p);
@@ -213,10 +213,10 @@ static inline int upipe_blit_sub_get_alpha_threshold(struct upipe *upipe,
  * @return an error code
  */
 static inline int upipe_blit_sub_set_alpha_threshold(struct upipe *upipe,
-        uint8_t threshold)
+        int threshold)
 {
     return upipe_control(upipe, UPIPE_BLIT_SUB_SET_ALPHA_THRESHOLD,
-                         UPIPE_BLIT_SUB_SIGNATURE, (unsigned)threshold);
+                         UPIPE_BLIT_SUB_SIGNATURE, threshold);
 }
 
 /** @This gets the z-index for this subpipe.

--- a/include/upipe/uref_pic.h
+++ b/include/upipe/uref_pic.h
@@ -218,7 +218,7 @@ static inline int uref_pic_blit(struct uref *uref, struct ubuf *ubuf,
                                 int dest_hoffset, int dest_voffset,
                                 int src_hoffset, int src_voffset,
                                 int extract_hsize, int extract_vsize,
-                                const uint8_t alpha, const uint8_t threshold)
+                                const int alpha, const int threshold)
 {
     if (uref->ubuf == NULL)
         return UBASE_ERR_INVALID;

--- a/include/upipe/uref_pic_flow_formats.h
+++ b/include/upipe/uref_pic_flow_formats.h
@@ -303,6 +303,48 @@ static const struct uref_pic_flow_format uref_pic_flow_format_yuv444p = {
 
 UREF_PIC_FLOW_FORMAT_HELPER(yuv444p);
 
+/** @This is the description of the yuva420p10le format */
+static const struct uref_pic_flow_format uref_pic_flow_format_yuva420p10le = {
+    .macropixel = 1,
+    .nb_planes = 4,
+    .planes = {
+        { 1, 1, 2, "y10l", 10 },
+        { 2, 2, 2, "u10l", 10 },
+        { 2, 2, 2, "v10l", 10 },
+        { 1, 1, 2, "a10l", 10 },
+    },
+};
+
+UREF_PIC_FLOW_FORMAT_HELPER(yuva420p10le);
+
+/** @This is the description of the yuva422p10le format */
+static const struct uref_pic_flow_format uref_pic_flow_format_yuva422p10le = {
+    .macropixel = 1,
+    .nb_planes = 4,
+    .planes = {
+        { 1, 1, 2, "y10l", 10 },
+        { 2, 1, 2, "u10l", 10 },
+        { 2, 1, 2, "v10l", 10 },
+        { 1, 1, 2, "a10l", 10 },
+    },
+};
+
+UREF_PIC_FLOW_FORMAT_HELPER(yuva422p10le);
+
+/** @This is the description of the yuva444p10le format */
+static const struct uref_pic_flow_format uref_pic_flow_format_yuva444p10le = {
+    .macropixel = 1,
+    .nb_planes = 4,
+    .planes = {
+        { 1, 1, 2, "y10l", 10 },
+        { 1, 1, 2, "u10l", 10 },
+        { 1, 1, 2, "v10l", 10 },
+        { 1, 1, 2, "a10l", 10 },
+    },
+};
+
+UREF_PIC_FLOW_FORMAT_HELPER(yuva444p10le);
+
 /** @This is the description of the yuv420p10le format */
 static const struct uref_pic_flow_format uref_pic_flow_format_yuv420p10le = {
     .macropixel = 1,

--- a/lib/upipe-modules/upipe_blit.c
+++ b/lib/upipe-modules/upipe_blit.c
@@ -148,9 +148,9 @@ struct upipe_blit_sub {
     struct uchain uchain;
 
     /** alpha multiplier */
-    uint8_t alpha;
+    int alpha;
     /** alpha blending method */
-    uint8_t alpha_threshold;
+    int alpha_threshold;
     /** z-index */
     int z_index;
     /** configured offset from the left border */
@@ -642,7 +642,7 @@ static int _upipe_blit_sub_set_margin(struct upipe *upipe,
  * @param alpha_p filled in with multiplier of the alpha channel
  * @return an error code
  */
-static int _upipe_blit_sub_get_alpha(struct upipe *upipe, uint8_t *alpha_p)
+static int _upipe_blit_sub_get_alpha(struct upipe *upipe, int *alpha_p)
 {
     struct upipe_blit_sub *sub = upipe_blit_sub_from_upipe(upipe);
     *alpha_p = sub->alpha;
@@ -655,7 +655,7 @@ static int _upipe_blit_sub_get_alpha(struct upipe *upipe, uint8_t *alpha_p)
  * @param alpha multiplier of the alpha channel
  * @return an error code
  */
-static int _upipe_blit_sub_set_alpha(struct upipe *upipe, uint8_t alpha)
+static int _upipe_blit_sub_set_alpha(struct upipe *upipe, int alpha)
 {
     struct upipe_blit_sub *sub = upipe_blit_sub_from_upipe(upipe);
     sub->alpha = alpha;
@@ -670,7 +670,7 @@ static int _upipe_blit_sub_set_alpha(struct upipe *upipe, uint8_t alpha)
  * @return an error code
  */
 static int _upipe_blit_sub_get_alpha_threshold(struct upipe *upipe,
-        uint8_t *threshold_p)
+        int *threshold_p)
 {
     struct upipe_blit_sub *sub = upipe_blit_sub_from_upipe(upipe);
     *threshold_p = sub->alpha_threshold;
@@ -684,7 +684,7 @@ static int _upipe_blit_sub_get_alpha_threshold(struct upipe *upipe,
  * @return an error code
  */
 static int _upipe_blit_sub_set_alpha_threshold(struct upipe *upipe,
-        uint8_t threshold)
+        int threshold)
 {
     struct upipe_blit_sub *sub = upipe_blit_sub_from_upipe(upipe);
     sub->alpha_threshold = threshold;
@@ -804,22 +804,22 @@ static int upipe_blit_sub_control(struct upipe *upipe,
         }
         case UPIPE_BLIT_SUB_GET_ALPHA: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_BLIT_SUB_SIGNATURE);
-            uint8_t *alpha_p = va_arg(args, uint8_t *);
+            int *alpha_p = va_arg(args, int *);
             return _upipe_blit_sub_get_alpha(upipe, alpha_p);
         }
         case UPIPE_BLIT_SUB_SET_ALPHA: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_BLIT_SUB_SIGNATURE);
-            unsigned alpha = va_arg(args, unsigned);
+            int alpha = va_arg(args, int);
             return _upipe_blit_sub_set_alpha(upipe, alpha);
         }
         case UPIPE_BLIT_SUB_GET_ALPHA_THRESHOLD: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_BLIT_SUB_SIGNATURE);
-            uint8_t *threshold_p = va_arg(args, uint8_t *);
+            int *threshold_p = va_arg(args, int *);
             return _upipe_blit_sub_get_alpha_threshold(upipe, threshold_p);
         }
         case UPIPE_BLIT_SUB_SET_ALPHA_THRESHOLD: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_BLIT_SUB_SIGNATURE);
-            unsigned threshold = va_arg(args, unsigned);
+            int threshold = va_arg(args, int);
             return _upipe_blit_sub_set_alpha_threshold(upipe, threshold);
         }
         case UPIPE_BLIT_SUB_GET_Z_INDEX: {

--- a/lib/upipe-modules/upipe_blit.c
+++ b/lib/upipe-modules/upipe_blit.c
@@ -433,19 +433,44 @@ static int upipe_blit_sub_provide_flow_format(struct upipe *upipe)
         uref_pic_set_hposition(uref, hposition);
         uref_pic_set_vposition(uref, vposition);
 
-        bool alpha =
-            ubase_check(uref_pic_flow_check_chroma(uref, 1, 1, 1, "a8")) ||
-            ubase_check(uref_pic_flow_check_chroma(uref, 1, 1, 1, "a16"));
+        /* Check for a dedicated alpha plane. */
+        uint8_t plane;
+        bool alpha = ubase_check(uref_pic_flow_find_chroma(uref, "a8", &plane))
+            || ubase_check(uref_pic_flow_find_chroma(uref, "a10l", &plane))
+            || ubase_check(uref_pic_flow_find_chroma(uref, "a16", &plane));
+
+        /* If there was a dedicated alpha plane then get its chroma string and
+         * macropixel size attributes. */
         const char *chroma;
-        if (!alpha && ubase_check(uref_pic_flow_get_chroma(uref, &chroma, 0)) &&
-            (strstr(chroma, "a8") != NULL || strstr(chroma, "a16") != NULL))
+        uint8_t macropixel_size;
+        if (alpha) {
+            UBASE_RETURN(uref_pic_flow_get_chroma(uref, &chroma, plane));
+            UBASE_RETURN(uref_pic_flow_get_macropixel_size(uref, &macropixel_size, plane));
+        }
+
+        /* Otherwise check for alpha in a packed first plane. */
+        else if (ubase_check(uref_pic_flow_get_chroma(uref, &chroma, 0)) &&
+                (strstr(chroma, "a8") || strstr(chroma, "a16"))) {
             alpha = true;
+            macropixel_size = 1;
+            chroma = "a8";
+        }
+
+        /* Duplicate the string because it might point to a udict internal
+         * address that is about to be overwritten. */
+        if (alpha) {
+            chroma = strdup(chroma);
+            UBASE_ALLOC_RETURN(chroma);
+        }
 
         uref_pic_flow_clear_format(uref);
         uref_pic_flow_copy_format(uref, upipe_blit->flow_def);
 
-        if (alpha)
-            uref_pic_flow_add_plane(uref, 1, 1, 1, "a8");
+        /* If the alpha was found add the alpha back into the flow format. */
+        if (alpha) {
+            uref_pic_flow_add_plane(uref, 1, 1, macropixel_size, chroma);
+            free((void*)chroma);
+        }
 
         uref_pic_flow_delete_sar(uref);
         uref_pic_flow_delete_overscan(uref);


### PR DESCRIPTION
A slightly experimental patch set for supporting a 10-bit alpha blend in upipe_blit.  It does work for me.

Possibly a mix of semi-related changes because I needed to get our program to support a particular use case.  I needed to get it to convert and scale SD rgba into HD yuva422p10le and correctly draw that onto the main yuv422p10le video.

One concern I have is the performance.  While testing I still had a bug which caused it to enter the wrong branch: the "on/off blending" branch with the divide by 0x3ff.  It caused the function to be the most costly function in the whole program.  The only goog was the compiler managed to optimize it into a multiply and right shift.  Fixing the bug so it didn't enter that branch gives much better performance.  I can't imagine how slow the true blend would be.