### PR TITLE
more optimization for ubuf_pic and upipe_set_color

### DIFF
--- a/lib/upipe/ubuf_pic.c
+++ b/lib/upipe/ubuf_pic.c
@@ -144,6 +144,23 @@ int ubuf_pic_plane_set_color(struct ubuf *ubuf, const char *chroma,
             memset(buf, pattern[0], mem_width);
             buf += stride;
         }
+
+#ifdef __x86_64__
+
+    } else if (pattern_size <= 16 && 16 % pattern_size == 0 && mem_width % 16 == 0) {
+        uint8_t __attribute__ ((aligned (16))) temp[16];
+        for (size_t i = 0; i < 16; i += 1)
+            temp[i] = pattern[i % pattern_size];
+        for (int y = 0; y < height; y++) {
+            uint8_t * const t = buf;
+            for (size_t x = 0; x < mem_width; x += 16) {
+                memcpy(t + x, temp, 16);
+            }
+            buf += stride;
+        }
+
+#endif
+
     } else {
         for (size_t i = 0; i < mem_width; i += pattern_size)
             memcpy(buf + i, pattern, pattern_size);

--- a/lib/upipe/ubuf_pic.c
+++ b/lib/upipe/ubuf_pic.c
@@ -135,11 +135,12 @@ int ubuf_pic_plane_set_color(struct ubuf *ubuf, const char *chroma,
     } else {
         height = vsize;
     }
+    height /= vsub;
 
     const size_t mem_width = width * macropixel_size / hsub / macropixel;
 
     if (pattern_size == 1) {
-        for (size_t i = 0; i < height / vsub; i++) {
+        for (size_t i = 0; i < height; i++) {
             memset(buf, pattern[0], mem_width);
             buf += stride;
         }
@@ -147,7 +148,7 @@ int ubuf_pic_plane_set_color(struct ubuf *ubuf, const char *chroma,
         for (size_t i = 0; i < mem_width; i += pattern_size)
             memcpy(buf + i, pattern, pattern_size);
 
-        for (int i = 1; i < height / vsub; i++) {
+        for (int i = 1; i < height; i++) {
             memcpy(buf + stride, buf, mem_width);
             buf += stride;
         }

--- a/lib/upipe/ubuf_pic.c
+++ b/lib/upipe/ubuf_pic.c
@@ -145,6 +145,7 @@ int ubuf_pic_plane_set_color(struct ubuf *ubuf, const char *chroma,
             buf += stride;
         }
 
+#if __GNUC__ >= 7
 #ifdef __x86_64__
 
     } else if (pattern_size <= 16 && 16 % pattern_size == 0 && mem_width % 16 == 0) {
@@ -159,6 +160,7 @@ int ubuf_pic_plane_set_color(struct ubuf *ubuf, const char *chroma,
             buf += stride;
         }
 
+#endif
 #endif
 
     } else {

--- a/tests/ubuf_pic_clear_test.c
+++ b/tests/ubuf_pic_clear_test.c
@@ -39,6 +39,9 @@
 #include <string.h>
 #include <assert.h>
 
+#include <time.h>
+#include <inttypes.h>
+
 #define UBUF_POOL_DEPTH     1
 #define UBUF_PREPEND        2
 #define UBUF_APPEND         2
@@ -95,6 +98,10 @@ static void check(struct ubuf *ubuf, const char *chroma,
 
 int main(int argc, char **argv)
 {
+    size_t loops = 0;
+    if (argc >= 2)
+        loops = atol(argv[1]);
+
     struct umem_mgr *umem_mgr = umem_alloc_mgr_alloc();
     assert(umem_mgr != NULL);
 
@@ -223,6 +230,56 @@ int main(int argc, char **argv)
     check(ubuf, "y10l", (uint8_t []){ 0, 0 }, 2);
     check(ubuf, "u10l", (uint8_t []){ 0, 2 }, 2);
     check(ubuf, "v10l", (uint8_t []){ 0, 2 }, 2);
+
+    ubuf_free(ubuf);
+    ubuf_mgr_release(mgr);
+
+    /* yuv422p10le */
+    mgr = ubuf_pic_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH, umem_mgr, 1,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_PREPEND, UBUF_APPEND,
+                                 UBUF_ALIGN, UBUF_ALIGN_HOFFSET);
+    assert(mgr != NULL);
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "y10l", 1, 1, 2));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "u10l", 2, 1, 2));
+    ubase_assert(ubuf_pic_mem_mgr_add_plane(mgr, "v10l", 2, 1, 2));
+
+    ubuf = ubuf_pic_alloc(mgr, 1920, 1080);
+    assert(ubuf != NULL);
+    fill_in(ubuf);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0));
+    check(ubuf, "y10l", (uint8_t []){ 64, 0 }, 2);
+    check(ubuf, "u10l", (uint8_t []){ 0, 2 }, 2);
+    check(ubuf, "v10l", (uint8_t []){ 0, 2 }, 2);
+
+    ubase_assert(ubuf_pic_clear(ubuf, 0, 0, -1, -1, 1));
+    check(ubuf, "y10l", (uint8_t []){ 0, 0 }, 2);
+    check(ubuf, "u10l", (uint8_t []){ 0, 2 }, 2);
+    check(ubuf, "v10l", (uint8_t []){ 0, 2 }, 2);
+
+#if 1
+    struct timespec t, t0, tp;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &t0);
+    tp = t0;
+
+    for (size_t l = 0; l < loops; /* do nothing */) {
+        ubuf_pic_clear(ubuf, 0, 0, -1, -1, 0);
+
+        if (++l % 8192 == 0) {
+            clock_gettime(CLOCK_MONOTONIC_RAW, &t);
+            uint64_t t_diff = t.tv_sec * UINT64_C(1000000000) + t.tv_nsec
+                - (tp.tv_sec * UINT64_C(1000000000) + tp.tv_nsec);
+            uint64_t t0_diff = t.tv_sec * UINT64_C(1000000000) + t.tv_nsec
+                - (t0.tv_sec * UINT64_C(1000000000) + t0.tv_nsec);
+
+            printf("%"PRIu64" calls to ubuf_pic_clear per second, avg: %"PRIu64"\n",
+                    8192 * UINT64_C(1000000000) / t_diff,
+                    l * UINT64_C(1000000000) / t0_diff);
+            tp = t;
+        }
+    }
+#endif
 
     ubuf_free(ubuf);
     ubuf_mgr_release(mgr);


### PR DESCRIPTION
This time I managed to get things right.  Again "add a basic benchmark for ubuf_pic_clear" is not supposed to be committed.

It compiles to what I expect on gcc as far back as 4.8.  That being a hot loop of 4 instructions: movdqu, add, cmp, conditional jump

The performance increase is much more modest than the original improvements.  From ~6500 to ~7000 calls per second on an AMD Ryzen 7 3700X desktop and from ~2600 to ~2900 on an Intel Xeon E3-1245 v5 server and from ~2000 to ~2200 on an Intel Xeon CPU E3-1265L v3 server with just 1 memory channel populated.

@nto if your previous measurements were done on an x86 system would you like to look at this patch set?