### PR TITLE
upipe_ts_demux: update highest timestamp

### DIFF
--- a/tests/upipe_ts_demux_test.c
+++ b/tests/upipe_ts_demux_test.c
@@ -380,7 +380,7 @@ int main(int argc, char *argv[])
 
     mp2vend_init(payload);
     uref_block_unmap(uref, 0);
-    expect_new_flow_def = 2;
+    expect_new_flow_def = 1;
     upipe_input(upipe_ts_demux, uref, NULL);
     assert(!expect_new_flow_def);
 


### PR DESCRIPTION
Update the highest timestamp after the framers as it might be interpolated.