### PR TITLE
Fix udict comparaison

### DIFF
--- a/lib/upipe/udict_inline.c
+++ b/lib/upipe/udict_inline.c
@@ -421,14 +421,6 @@ static int udict_inline_set(struct udict *udict, const char *name,
                 *attr_p = attr;
             return UBASE_ERR_NONE;
         }
-        if (likely(base_type == UDICT_TYPE_STRING &&
-                   current_size > attr_size)) {
-            /* Just zero out superfluous bytes */
-            memset(attr + attr_size, 0, current_size - attr_size);
-            if (attr_p != NULL)
-                *attr_p = attr;
-            return UBASE_ERR_NONE;
-        }
         udict_inline_delete(udict, name, type);
     }
 

--- a/tests/udict_inline_test.c
+++ b/tests/udict_inline_test.c
@@ -146,6 +146,20 @@ int main(int argc, char **argv)
     udict_free(udict2);
 
     udict_free(udict1);
+
+    {
+        struct udict *udict1 = udict_alloc(mgr, 0);
+        struct udict *udict2 = udict_alloc(mgr, 0);
+
+        udict_set_string(udict1, "void.", UDICT_TYPE_STRING, "f.def");
+        udict_set_string(udict2, "pic.", UDICT_TYPE_STRING, "f.def");
+        assert(udict_cmp(udict1, udict2) != 0);
+        udict_set_string(udict1, "pic.", UDICT_TYPE_STRING, "f.def");
+        assert(udict_cmp(udict1, udict2) == 0);
+        udict_free(udict1);
+        udict_free(udict2);
+    }
+
     udict_mgr_release(mgr);
 
     umem_mgr_release(umem_mgr);


### PR DESCRIPTION
Remove udict optimization when setting an existing string attribute with a smaller content. This optimization may cause issues when comparing the udict as the attribute size may be different for the same content.