### PR TITLE
uuri: fix undefined behaviour

### DIFF
--- a/lib/upipe/uuri.c
+++ b/lib/upipe/uuri.c
@@ -120,10 +120,13 @@ ssize_t uuri_unescape(const char *path, char *buffer, size_t size)
 
     while (!ustring_is_empty(str)) {
         struct ustring tmp = ustring_split_until(&str, "%");
-        memcpy(buffer, tmp.at, tmp.len > size ? size : tmp.len);
+        size_t len = tmp.len > size ? size : tmp.len;
+        if (buffer) {
+            memcpy(buffer, tmp.at, len);
+            buffer += len;
+        }
+        size -= len;
         s += tmp.len;
-        buffer += tmp.len;
-        size -= size > tmp.len ? tmp.len : size;
 
         if (ustring_is_empty(str))
             break;
@@ -132,10 +135,9 @@ ssize_t uuri_unescape(const char *path, char *buffer, size_t size)
         if (ustring_is_empty(pct))
             return -1;
         if (size) {
-            buffer[0] = uuri_pct_decode(pct);
+            *buffer++ = uuri_pct_decode(pct);
             size--;
         }
-        buffer++;
         s++;
     }
     if (size)

--- a/tests/uuri_test.c
+++ b/tests/uuri_test.c
@@ -303,9 +303,10 @@ static void test_escape(void)
         assert(uuri_escape(paths[i], escape, sizeof (escape)) == len);
         printf("escaped path %s -> %s\n", paths[i], escape);
 
-        assert(uuri_unescape_len(escape) <= strlen(paths[i]));
+        len = uuri_unescape_len(escape);
+        assert(len >= 0 && len <= strlen(paths[i]));
         char unescape[strlen(paths[i]) + 1];
-        assert(uuri_unescape(escape, unescape, sizeof (unescape)) >= 0);
+        assert(uuri_unescape(escape, unescape, sizeof (unescape)) == len);
         assert(!strcmp(paths[i], unescape));
     }
 }


### PR DESCRIPTION
Allow calling uuri_unescape() with null buffer.