### PR TITLE
upipe-modules: make all pipes throw ready and dead events

### DIFF
--- a/lib/upipe-modules/upipe_row_join.c
+++ b/lib/upipe-modules/upipe_row_join.c
@@ -153,6 +153,7 @@ static int upipe_row_join_control(struct upipe *upipe, int command,
 
 static void upipe_row_join_free(struct upipe *upipe)
 {
+    upipe_throw_dead(upipe);
     upipe_row_join_clean_ubuf_mgr(upipe);
     upipe_row_join_clean_urefcount(upipe);
     upipe_row_join_clean_output(upipe);
@@ -178,6 +179,7 @@ static struct upipe *upipe_row_join_alloc(struct upipe_mgr *mgr,
     upipe_row_join_init_ubuf_mgr(upipe);
     upipe_row_join_init_urefcount(upipe);
 
+    upipe_throw_ready(upipe);
     return upipe;
 }
 

--- a/lib/upipe-modules/upipe_rtp_pcm_pack.c
+++ b/lib/upipe-modules/upipe_rtp_pcm_pack.c
@@ -295,6 +295,7 @@ static struct upipe *upipe_rtp_pcm_pack_alloc(struct upipe_mgr *mgr,
     upipe_rtp_pcm_pack->output_time = 0;
     upipe_rtp_pcm_pack->output_samples = 0;
 
+    upipe_throw_ready(upipe);
     return upipe;
 }
 

--- a/lib/upipe-modules/upipe_separate_fields.c
+++ b/lib/upipe-modules/upipe_separate_fields.c
@@ -131,6 +131,7 @@ static int upipe_separate_fields_control(struct upipe *upipe, int command,
 
 static void upipe_separate_fields_free(struct upipe *upipe)
 {
+    upipe_throw_dead(upipe);
     upipe_separate_fields_clean_urefcount(upipe);
     upipe_separate_fields_clean_output(upipe);
     upipe_separate_fields_free_void(upipe);
@@ -148,6 +149,7 @@ static struct upipe *upipe_separate_fields_alloc(struct upipe_mgr *mgr,
 
     upipe_separate_fields_init_urefcount(upipe);
     upipe_separate_fields_init_output(upipe);
+    upipe_throw_ready(upipe);
 
     return upipe;
 }


### PR DESCRIPTION
A small FYI.

I found these files by searching for all files which matched 'UPIPE_HELPER|upipe_throw_ready|upipe_throw_dead' meaning they were probably the main files for pipes.  Then I filtered that list for files which did not match 'upipe_throw_dead' or 'upipe_throw_ready'.

Specifically I ran these commands:
```
vim $(rg --files-without-match upipe_throw_ready -- $(rg -l 'UPIPE_HELPER|upipe_throw_ready|upipe_throw_dead' lib/))
vim $(rg --files-without-match upipe_throw_dead -- $(rg -l 'UPIPE_HELPER|upipe_throw_ready|upipe_throw_dead' lib/))
```