### PR TITLE
upipe_avcdec: don't use hardcoded extra hw frames

### DIFF
--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -805,9 +805,6 @@ static bool upipe_avcdec_do_av_deal(struct upipe *upipe)
             upipe_throw_fatal(upipe, UBASE_ERR_EXTERNAL);
             return false;
         }
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 11, 100)
-        context->extra_hw_frames = UPIPE_AV_EXTRA_HW_FRAMES;
-#endif
         upipe_notice_va(upipe, "created %s hw device context (%s)",
                         av_hwdevice_get_type_name(upipe_avcdec->hw_device_type),
                         upipe_avcdec->hw_device ?: "default");


### PR DESCRIPTION
Caller can use upipe_set_option("extra_hw_frames") to set a custom hw frame count if needed.