### PR TITLE
upipe_avfilter: don't use hardcoded extra hw frames

### DIFF
--- a/lib/upipe-av/upipe_av_internal.h
+++ b/lib/upipe-av/upipe_av_internal.h
@@ -39,9 +39,6 @@
 #include <libavutil/error.h>
 #include <libavcodec/avcodec.h>
 
-/** extra hardware frames for decode and filter */
-#define UPIPE_AV_EXTRA_HW_FRAMES 32
-
 /** @hidden */
 struct uref;
 /** @hidden */

--- a/lib/upipe-av/upipe_avfilter.c
+++ b/lib/upipe-av/upipe_avfilter.c
@@ -2152,9 +2152,6 @@ static int upipe_avfilt_init_buffer_from_first_frame(struct upipe *upipe,
     if (device_ctx != NULL) {
         AVFilterGraph *graph = upipe_avfilt->filter_graph;
         for (int i = 0; i < graph->nb_filters; i++) {
-#if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(7, 12, 100)
-            graph->filters[i]->extra_hw_frames = UPIPE_AV_EXTRA_HW_FRAMES;
-#endif
             graph->filters[i]->hw_device_ctx = av_buffer_ref(device_ctx);
             if (graph->filters[i]->hw_device_ctx == NULL) {
                 upipe_err(upipe, "cannot alloc hw device context");


### PR DESCRIPTION
Caller can use the "extra_hw_frames" filter option to set a custom hw frame count if needed.