### PR TITLE
upipe-pthread: add umutex_pthread_trylock

### DIFF
--- a/include/upipe-pthread/umutex_pthread.h
+++ b/include/upipe-pthread/umutex_pthread.h
@@ -28,6 +28,13 @@ extern "C" {
  */
 struct umutex *umutex_pthread_alloc(const pthread_mutexattr_t *mutexattr);
 
+/** @This tries to lock a mutex.
+ *
+ * @param umutex pointer to a umutex structure
+ * @return an error code, UBASE_ERR_BUSY for EBUSY
+ */
+int umutex_pthread_trylock(struct umutex *umutex);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/upipe-pthread/umutex_pthread.c
+++ b/lib/upipe-pthread/umutex_pthread.c
@@ -51,6 +51,23 @@ static inline int umutex_pthread_lock(struct umutex *umutex)
     }
 }
 
+/** @This tries to lock a mutex.
+ *
+ * @param umutex pointer to a umutex structure
+ * @return an error code, UBASE_ERR_BUSY for EBUSY
+ */
+int umutex_pthread_trylock(struct umutex *umutex)
+{
+    struct umutex_pthread *umutex_pthread = umutex_pthread_from_umutex(umutex);
+    int err = pthread_mutex_trylock(&umutex_pthread->mutex);
+    switch (err) {
+        case 0: return UBASE_ERR_NONE;
+        case EBUSY: return UBASE_ERR_BUSY;
+        default:
+        case EINVAL: return UBASE_ERR_INVALID;
+    }
+}
+
 /** @This unlocks a mutex.
  *
  * @param umutex pointer to a umutex structure


### PR DESCRIPTION
Allows the user to call pthread_mutex_trylock() on a umutex provided by this module.  Lets the call return UBASE_ERR_BUSY if the mutex is already locked on another thread.