### PR TITLE
upipe_ffmt: support setscan for deinterlacing

### DIFF
--- a/include/upipe-modules/upipe_setscan.h
+++ b/include/upipe-modules/upipe_setscan.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 EasyTools
+ *
+ * Authors: Arnaud de Turckheim
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file
+ * @short Upipe module to force scan
+ */
+
+#ifndef _UPIPE_MODULES_UPIPE_SETSCAN_H_
+/** @hidden */
+#define _UPIPE_MODULES_UPIPE_SETSCAN_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "upipe/upipe.h"
+
+#define UPIPE_SETSCAN_SIGNATURE UBASE_FOURCC('s','s','c','n')
+
+/** @This returns the management structure for all setscan pipes.
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_setscan_mgr_alloc(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/upipe-filters/upipe_filter_format.c
+++ b/lib/upipe-filters/upipe_filter_format.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2016 OpenHeadend S.A.R.L.
+ * Copyright (C) 2026 EasyTools
  *
  * Authors: Christophe Massiot
  *
@@ -703,16 +704,21 @@ static int upipe_ffmt_check_flow_format(struct upipe *upipe,
 
         if (need_deint) {
             upipe_notice(upipe, "need deinterlace");
-            struct upipe *input = upipe_void_alloc(ffmt_mgr->deint_mgr,
-                    uprobe_pfx_alloc(
-                        need_sws ? uprobe_use(&upipe_ffmt->proxy_probe) :
-                                   uprobe_use(&upipe_ffmt->last_inner_probe),
-                        UPROBE_LOG_VERBOSE, "deint"));
-            if (unlikely(input == NULL))
-                upipe_warn_va(upipe, "couldn't allocate deinterlace");
-            else if (!need_sws)
-                upipe_ffmt_store_bin_output(upipe, upipe_use(input));
-            upipe_ffmt_store_bin_input(upipe, input);
+            struct upipe *input = upipe_flow_alloc(
+                ffmt_mgr->deint_mgr,
+                uprobe_pfx_alloc(uprobe_use(&upipe_ffmt->proxy_probe),
+                                 UPROBE_LOG_VERBOSE, "deint"),
+                flow_def_dup);
+            if (unlikely(input == NULL)) {
+                input = upipe_void_alloc(
+                    ffmt_mgr->deint_mgr,
+                    uprobe_pfx_alloc(uprobe_use(&upipe_ffmt->proxy_probe),
+                                     UPROBE_LOG_VERBOSE, "deint"));
+                if (unlikely(input == NULL))
+                    upipe_warn_va(upipe, "couldn't allocate deinterlace");
+            }
+            if (likely(input))
+                upipe_ffmt_store_bin_input(upipe, input);
         }
 
         if (need_sws) {

--- a/lib/upipe-modules/Build.mk
+++ b/lib/upipe-modules/Build.mk
@@ -62,6 +62,7 @@ libupipe_modules-includes = \
     upipe_setattr.h \
     upipe_setflowdef.h \
     upipe_setrap.h \
+    upipe_setscan.h \
     upipe_sine_wave_source.h \
     upipe_skip.h \
     upipe_stream_switcher.h \
@@ -146,6 +147,7 @@ libupipe_modules-src = \
     upipe_setattr.c \
     upipe_setflowdef.c \
     upipe_setrap.c \
+    upipe_setscan.c \
     upipe_sine_wave_source.c \
     upipe_skip.c \
     upipe_stream_switcher.c \

--- a/lib/upipe-modules/upipe_setscan.c
+++ b/lib/upipe-modules/upipe_setscan.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2026 EasyTools
+ *
+ * Authors: Arnaud de Turckheim
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file
+ * @short Upipe module to force scan
+ */
+
+#include "upipe/uref_pic.h"
+#include "upipe/uref_pic_flow.h"
+#include "upipe/uprobe_prefix.h"
+#include "upipe/upipe_helper_upipe.h"
+#include "upipe/upipe_helper_flow.h"
+#include "upipe/upipe_helper_urefcount.h"
+#include "upipe/upipe_helper_output.h"
+#include "upipe-modules/upipe_setscan.h"
+#include "upipe-modules/upipe_setflowdef.h"
+#include "upipe-modules/upipe_probe_uref.h"
+
+/** @internal @This is the private structure for a setscan pipe. */
+struct upipe_setscan {
+    /** public refcount management structure */
+    struct urefcount urefcount;
+    /** output pipe */
+    struct upipe *output;
+    /** output state */
+    enum upipe_helper_output_state output_state;
+    /** output flow definition */
+    struct uref *flow_def;
+    /** request list */
+    struct uchain requests;
+    /** public upipe structure */
+    struct upipe upipe;
+    /** force progressive or interlaced */
+    bool progressive;
+};
+
+UPIPE_HELPER_UPIPE(upipe_setscan, upipe, UPIPE_SETSCAN_SIGNATURE)
+UPIPE_HELPER_FLOW(upipe_setscan, UREF_PIC_FLOW_DEF)
+UPIPE_HELPER_UREFCOUNT(upipe_setscan, urefcount, upipe_setscan_free)
+UPIPE_HELPER_OUTPUT(upipe_setscan, output, flow_def, output_state, requests);
+
+
+/** @internal @This allocates a setscan pipe.
+ *
+ * @param mgr common management structure
+ * @param uprobe structure used to raise events
+ * @param signature signature of the pipe allocator
+ * @param args optional arguments
+ * @return pointer to upipe or NULL in case of allocation error
+ */
+static struct upipe *upipe_setscan_alloc(struct upipe_mgr *mgr,
+                                         struct uprobe *uprobe,
+                                         uint32_t signature, va_list args)
+{
+    struct uref *flow_def = NULL;
+    struct upipe *upipe =
+        upipe_setscan_alloc_flow(mgr, uprobe, signature, args, &flow_def);
+    if (unlikely(!upipe))
+        return NULL;
+
+    struct upipe_setscan *upipe_setscan = upipe_setscan_from_upipe(upipe);
+
+    upipe_setscan_init_urefcount(upipe);
+    upipe_setscan_init_output(upipe);
+    upipe_setscan->progressive = uref_pic_check_progressive(flow_def);
+    uref_free(flow_def);
+
+    upipe_throw_ready(upipe);
+
+    return upipe;
+}
+
+/** @internal @This is called when there is no more references on the pipe and
+ * frees it.
+ *
+ * @param upipe description structure of the pipe
+ */
+static void upipe_setscan_free(struct upipe *upipe)
+{
+    upipe_throw_dead(upipe);
+
+    upipe_setscan_clean_output(upipe);
+    upipe_setscan_clean_urefcount(upipe);
+    upipe_setscan_free_flow(upipe);
+}
+
+/** @internal @This handles the input buffer.
+ *
+ * @param upipe description structure of the pipe
+ * @param uref input buffer to handle
+ * @param upump_p reference to pump that generated the buffer
+ */
+static void upipe_setscan_input(struct upipe *upipe, struct uref *uref,
+                                struct upump **upump_p)
+{
+    struct upipe_setscan *upipe_setscan = upipe_setscan_from_upipe(upipe);
+    uref_pic_set_progressive(uref, upipe_setscan->progressive);
+    upipe_setscan_output(upipe, uref, upump_p);
+}
+
+/** @internal @This sets the input flow definition.
+ *
+ * @param upipe description structure of the pipe
+ * @param flow_def input flow definition packet
+ * @return an error code
+ */
+static int upipe_setscan_set_flow_def(struct upipe *upipe,
+                                      struct uref *flow_def)
+{
+    struct upipe_setscan *upipe_setscan = upipe_setscan_from_upipe(upipe);
+    if (unlikely(!flow_def))
+        return UBASE_ERR_INVALID;
+    UBASE_RETURN(uref_flow_match_def(flow_def, UREF_PIC_FLOW_DEF));
+    struct uref *flow_def_dup = uref_dup(flow_def);
+    UBASE_ALLOC_RETURN(flow_def_dup);
+    uref_pic_set_progressive(flow_def_dup, upipe_setscan->progressive);
+    upipe_setscan_store_flow_def(upipe, flow_def_dup);
+    return UBASE_ERR_NONE;
+}
+
+/** @internal @This handles control command on the pipe.
+ *
+ * @param upipe description structure of the pipe
+ * @param command control command to handle
+ * @param args arguments of the command
+ * @return an error code
+ */
+static int upipe_setscan_control(struct upipe *upipe, int command, va_list args)
+{
+    switch (command) {
+        case UPIPE_SET_FLOW_DEF: {
+            struct uref *flow_def = va_arg(args, struct uref *);
+            return upipe_setscan_set_flow_def(upipe, flow_def);
+        }
+    }
+    return upipe_setscan_control_output(upipe, command, args);
+}
+
+/** @internal @This is the static setscan pipe management structure. */
+static struct upipe_mgr upipe_setscan_mgr = {
+    .refcount = NULL,
+    .signature = UPIPE_SETSCAN_SIGNATURE,
+
+    .upipe_alloc = upipe_setscan_alloc,
+    .upipe_input = upipe_setscan_input,
+    .upipe_control = upipe_setscan_control,
+
+    .upipe_mgr_control = NULL
+};
+
+/** @This returns the management structure for setscan pipes
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_setscan_mgr_alloc(void)
+{
+    return &upipe_setscan_mgr;
+}

--- a/tests/Build.mk
+++ b/tests/Build.mk
@@ -352,6 +352,10 @@ tests += upipe_setrap_test
 upipe_setrap_test-src = upipe_setrap_test.c
 upipe_setrap_test-libs = libupipe libupipe_modules
 
+tests += upipe_setscan_test
+upipe_setscan_test-src = upipe_setscan_test.c
+upipe_setscan_test-libs = libupipe libupipe_modules
+
 tests += upipe_skip_test
 upipe_skip_test-src = upipe_skip_test.c
 upipe_skip_test-libs = libupipe libupipe_modules

--- a/tests/upipe_setscan_test.c
+++ b/tests/upipe_setscan_test.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 EasyTools
+ *
+ * Authors: Arnaud de Turckheim
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "upipe/uprobe.h"
+#include "upipe/uprobe_prefix.h"
+#include "upipe/uprobe_stdio.h"
+#include "upipe/uprobe_ubuf_mem.h"
+#include "upipe/umem.h"
+#include "upipe/umem_alloc.h"
+#include "upipe/udict.h"
+#include "upipe/udict_inline.h"
+#include "upipe/ubuf.h"
+#include "upipe/ubuf_mem.h"
+#include "upipe/uref.h"
+#include "upipe/uref_pic_flow.h"
+#include "upipe/uref_pic.h"
+#include "upipe/uref_pic_flow_formats.h"
+#include "upipe/uref_std.h"
+#include "upipe/upipe.h"
+#include "upipe-modules/upipe_setscan.h"
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#undef NDEBUG
+#define UPROBE_LOG_LEVEL UPROBE_LOG_DEBUG
+#define COUNT               10
+#define WIDTH               720
+#define HEIGHT              576
+
+static struct uref_mgr *uref_mgr;
+static bool output_progressive;
+static int in_count = 0, out_count = 0;
+
+/** definition of our uprobe */
+static int catch(struct uprobe *uprobe, struct upipe *upipe,
+                 int event, va_list args)
+{
+    switch (event) {
+        default:
+            assert(0);
+            break;
+        case UPROBE_READY:
+        case UPROBE_DEAD:
+        case UPROBE_NEW_FLOW_DEF:
+            break;
+    }
+    return UBASE_ERR_NONE;
+}
+
+static int sink_control(struct upipe *upipe, int command, va_list args)
+{
+    switch (command) {
+        case UPIPE_SET_FLOW_DEF: {
+            struct uref *flow_def = va_arg(args, struct uref *);
+            bool progressive;
+            ubase_assert(uref_pic_get_progressive(flow_def, &progressive));
+            assert(progressive == output_progressive);
+            return UBASE_ERR_NONE;
+        }
+    }
+    return UBASE_ERR_UNHANDLED;
+}
+
+static void sink_input(struct upipe *upipe, struct uref *uref,
+                       struct upump **upump_p)
+{
+    bool progressive;
+    uref_pic_get_progressive(uref, &progressive);
+    assert(progressive == output_progressive);
+    uref_free(uref);
+    upipe_dbg_va(upipe, "Receiving pic %d", out_count);
+    out_count++;
+}
+
+static struct upipe_mgr sink_mgr = {
+    .upipe_input = sink_input,
+    .upipe_control = sink_control,
+};
+
+int main(int argc, char **argv)
+{
+    struct uref *pic;
+    struct uref *input_flow_def, *output_flow_def;
+    struct upipe *setscan;
+    struct ubuf_mgr *ubuf_mgr;
+
+    /* upipe env */
+    struct umem_mgr *umem_mgr = umem_alloc_mgr_alloc();
+    assert(umem_mgr != NULL);
+    struct udict_mgr *udict_mgr = udict_inline_mgr_alloc(0, umem_mgr, -1, -1);
+    assert(udict_mgr != NULL);
+    uref_mgr = uref_std_mgr_alloc(0, udict_mgr, 0);
+    assert(uref_mgr != NULL);
+
+    struct uprobe uprobe;
+    uprobe_init(&uprobe, catch, NULL);
+    struct uprobe *logger = uprobe_stdio_alloc(&uprobe, stdout,
+                                               UPROBE_LOG_LEVEL);
+    assert(logger != NULL);
+    logger = uprobe_ubuf_mem_alloc(logger, umem_mgr, 0, 0);
+    assert(logger != NULL);
+
+    struct upipe_mgr *setscan_mgr = upipe_setscan_mgr_alloc();
+    assert(setscan_mgr);
+
+    struct upipe sink;
+    upipe_init(&sink, &sink_mgr, uprobe_use(logger));
+
+    /* output progressive */
+    output_progressive = true;
+    input_flow_def = uref_pic_flow_alloc_yuv420p(uref_mgr);
+    uref_pic_set_progressive(input_flow_def, !output_progressive);
+    output_flow_def = uref_pic_flow_alloc_yuv420p(uref_mgr);
+    uref_pic_set_progressive(output_flow_def, output_progressive);
+
+    /* setscan */
+    setscan = upipe_flow_alloc(
+        setscan_mgr,
+        uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "setscan"),
+        output_flow_def);
+    assert(setscan);
+    ubase_assert(upipe_set_flow_def(setscan, input_flow_def));
+    ubase_assert(upipe_set_output(setscan, &sink));
+
+    /* ubuf manager */
+    ubuf_mgr = ubuf_mem_mgr_alloc_from_flow_def(0, 0, umem_mgr, input_flow_def);
+    for (in_count = 0, out_count = 0; in_count < COUNT; in_count++) {
+        uprobe_dbg_va(logger, NULL, "Sending pic %d", in_count);
+        pic = uref_pic_alloc(uref_mgr, ubuf_mgr, WIDTH, HEIGHT);
+        assert(pic);
+
+        const char *chroma;
+        uref_pic_foreach_plane(pic, chroma) {
+            int x, y;
+            uint8_t *buf, macropixel = 0;
+            uint8_t vsub, hsub;
+            size_t stride = 0;
+
+            ubase_assert(uref_pic_plane_write(pic, chroma, 0, 0, -1, -1, &buf));
+            ubase_assert(uref_pic_plane_size(pic, chroma, &stride, &hsub, &vsub,
+                                             &macropixel));
+            for (y = 0; y < HEIGHT / vsub; y++) {
+                for (x = 0; x < WIDTH / vsub; x++) {
+                    buf[macropixel * x] = x + y + in_count * 3;
+                    buf[macropixel * x + 1] = x + y + in_count * 3 * 10;
+                    buf[macropixel * x + 2] = x + y + in_count * 3 * 10;
+                }
+                buf += stride;
+            }
+            uref_pic_plane_unmap(pic, chroma, 0, 0, -1, -1);
+        }
+        upipe_input(setscan, pic, NULL);
+    }
+    ubuf_mgr_release(ubuf_mgr);
+    upipe_release(setscan);
+    uref_free(output_flow_def);
+    uref_free(input_flow_def);
+    assert(out_count == COUNT);
+
+    /* output interlaced */
+    output_progressive = false;
+    input_flow_def = uref_pic_flow_alloc_yuv420p(uref_mgr);
+    uref_pic_set_progressive(input_flow_def, !output_progressive);
+    output_flow_def = uref_pic_flow_alloc_yuv420p(uref_mgr);
+    uref_pic_set_progressive(output_flow_def, output_progressive);
+
+    /* setscan */
+    setscan = upipe_flow_alloc(
+        setscan_mgr,
+        uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "setscan"),
+        output_flow_def);
+    assert(setscan);
+    ubase_assert(upipe_set_flow_def(setscan, input_flow_def));
+    ubase_assert(upipe_set_output(setscan, &sink));
+
+    /* ubuf manager */
+    ubuf_mgr = ubuf_mem_mgr_alloc_from_flow_def(0, 0, umem_mgr, input_flow_def);
+    for (in_count = 0, out_count = 0; in_count < COUNT; in_count++) {
+        uprobe_dbg_va(logger, NULL, "Sending pic %d", in_count);
+        pic = uref_pic_alloc(uref_mgr, ubuf_mgr, WIDTH, HEIGHT);
+        assert(pic);
+
+        const char *chroma;
+        uref_pic_foreach_plane(pic, chroma) {
+            int x, y;
+            uint8_t *buf, macropixel = 0;
+            uint8_t vsub, hsub;
+            size_t stride = 0;
+
+            ubase_assert(uref_pic_plane_write(pic, chroma, 0, 0, -1, -1, &buf));
+            ubase_assert(uref_pic_plane_size(pic, chroma, &stride, &hsub, &vsub,
+                                             &macropixel));
+            for (y = 0; y < HEIGHT / vsub; y++) {
+                for (x = 0; x < WIDTH / vsub; x++) {
+                    buf[macropixel * x] = x + y + in_count * 3;
+                    buf[macropixel * x + 1] = x + y + in_count * 3 * 10;
+                    buf[macropixel * x + 2] = x + y + in_count * 3 * 10;
+                }
+                buf += stride;
+            }
+            uref_pic_plane_unmap(pic, chroma, 0, 0, -1, -1);
+        }
+        upipe_input(setscan, pic, NULL);
+    }
+    ubuf_mgr_release(ubuf_mgr);
+    upipe_release(setscan);
+    uref_free(output_flow_def);
+    assert(out_count == COUNT);
+
+    uref_free(input_flow_def);
+    upipe_clean(&sink);
+    upipe_mgr_release(setscan_mgr);
+    uref_mgr_release(uref_mgr);
+    uprobe_release(logger);
+    uprobe_clean(&uprobe);
+    udict_mgr_release(udict_mgr);
+    umem_mgr_release(umem_mgr);
+    return 0;
+}


### PR DESCRIPTION
Mark input flow definition and buffers as progressive before scaling when faking deinterlace to preserve quality.