### PR TITLE
uprobe_dup: new probe that duplicates an event to a second probe

### DIFF
--- a/include/upipe/uprobe_dup.h
+++ b/include/upipe/uprobe_dup.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file
+ * @short probe catching events and duplicating them to another probe
+ */
+
+#ifndef _UPIPE_UPROBE_DUP_H_
+/** @hidden */
+#define _UPIPE_UPROBE_DUP_H_
+
+#include "upipe/uprobe.h"
+#include "upipe/uprobe_helper_uprobe.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @This is a super-set of the uprobe structure with additional local
+ * members. */
+struct uprobe_dup {
+    /** pointer to duplicate probe */
+    struct uprobe *dup;
+
+    /** event to duplicate */
+    int event;
+
+    /** structure exported to modules */
+    struct uprobe uprobe;
+};
+
+UPROBE_HELPER_UPROBE(uprobe_dup, uprobe)
+
+/** @This initializes an already allocated uprobe_dup structure.
+ *
+ * @param uprobe_dup pointer to the already allocated structure
+ * @param next next probe to test if this one doesn't catch the event
+ * @param dup second probe to duplicate the event to
+ * @param event the event to catch and duplicate
+ * @return pointer to uprobe, or NULL in case of error
+ */
+struct uprobe *uprobe_dup_init(struct uprobe_dup *uprobe_dup,
+                               struct uprobe *next,
+                               struct uprobe *dup,
+                               int event);
+
+/** @This cleans a uprobe_dup structure.
+ *
+ * @param uprobe_dup structure to clean
+ */
+void uprobe_dup_clean(struct uprobe_dup *uprobe_dup);
+
+/** @This allocates a new uprobe_dup structure.
+ *
+ * @param next next probe to test if this one doesn't catch the event
+ * @param dup second probe to duplicate the event to
+ * @param event the event to catch and duplicate
+ * @return pointer to uprobe, or NULL in case of error
+ */
+struct uprobe *uprobe_dup_alloc(struct uprobe *next, struct uprobe *dup, int event);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/upipe/Build.mk
+++ b/lib/upipe/Build.mk
@@ -70,6 +70,7 @@ libupipe-includes = \
     upool.h \
     uprobe.h \
     uprobe_dejitter.h \
+    uprobe_dup.h \
     uprobe_helper.h \
     uprobe_helper_alloc.h \
     uprobe_helper_uprobe.h \
@@ -140,6 +141,7 @@ libupipe-src = \
     upipe_dump.c \
     uprobe.c \
     uprobe_dejitter.c \
+    uprobe_dup.c \
     uprobe_loglevel.c \
     uprobe_prefix.c \
     uprobe_select_flows.c \

--- a/lib/upipe/uprobe_dup.c
+++ b/lib/upipe/uprobe_dup.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file
+ * @short probe catching events and duplicating them to another probe
+ */
+
+#include "upipe/uprobe.h"
+#include "upipe/uprobe_dup.h"
+#include "upipe/uprobe_helper_alloc.h"
+
+/** @internal @This catches events thrown by pipes.
+ *
+ * @param uprobe pointer to probe
+ * @param upipe pointer to pipe throwing the event
+ * @param event event thrown
+ * @param args optional event-specific parameters
+ * @return an error code
+ */
+static int uprobe_dup_throw(struct uprobe *uprobe, struct upipe *upipe,
+                            int event, va_list args)
+{
+    struct uprobe_dup *uprobe_dup =
+        uprobe_dup_from_uprobe(uprobe);
+
+    if (event == uprobe_dup->event) {
+        va_list args_copy;
+        va_copy(args_copy, args);
+        uprobe_throw_va(uprobe_dup->dup, upipe, event, args_copy);
+        va_end(args_copy);
+    }
+
+    return uprobe_throw_next(uprobe, upipe, event, args);
+}
+
+/** @This initializes an already allocated uprobe_dup structure.
+ *
+ * @param uprobe_dup pointer to the already allocated structure
+ * @param next next probe to test
+ * @param dup second probe to duplicate the event to
+ * @param event the event to catch and duplicate
+ * @return pointer to uprobe, or NULL in case of error
+ */
+struct uprobe *uprobe_dup_init(struct uprobe_dup *uprobe_dup,
+                               struct uprobe *next,
+                               struct uprobe *dup,
+                               int event)
+{
+    assert(uprobe_dup != NULL);
+    struct uprobe *uprobe = uprobe_dup_to_uprobe(uprobe_dup);
+    uprobe_dup->dup = uprobe_use(dup);
+    uprobe_dup->event = event;
+    uprobe_init(uprobe, uprobe_dup_throw, next);
+    return uprobe;
+}
+
+/** @This cleans a uprobe_dup structure.
+ *
+ * @param uprobe_dup structure to clean
+ */
+void uprobe_dup_clean(struct uprobe_dup *uprobe_dup)
+{
+    assert(uprobe_dup != NULL);
+    struct uprobe *uprobe = uprobe_dup_to_uprobe(uprobe_dup);
+    uprobe_release(uprobe_dup->dup);
+    uprobe_clean(uprobe);
+}
+
+#define ARGS_DECL struct uprobe *next, struct uprobe *dup, int event
+#define ARGS next, dup, event
+UPROBE_HELPER_ALLOC(uprobe_dup)
+#undef ARGS
+#undef ARGS_DECL

--- a/tests/Build.mk
+++ b/tests/Build.mk
@@ -571,6 +571,10 @@ tests += uprobe_dejitter_test
 uprobe_dejitter_test-src = uprobe_dejitter_test.c
 uprobe_dejitter_test-libs = libupipe
 
+tests += uprobe_dup_test
+uprobe_dup_test-src = uprobe_dup_test.c
+uprobe_dup_test-libs = libupipe
+
 tests += uprobe_prefix_test.sh
 uprobe_prefix_test.sh-deps = uprobe_prefix_test
 

--- a/tests/uprobe_dup_test.c
+++ b/tests/uprobe_dup_test.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/** @file
+ * @short unit tests for uprobe_dup implementation
+ */
+
+#undef NDEBUG
+
+#include "upipe/uprobe.h"
+#include "upipe/uprobe_stdio.h"
+#include "upipe/uprobe_dup.h"
+#include "upipe/upipe.h"
+
+#include <stdio.h>
+#include <assert.h>
+
+#define UDICT_POOL_DEPTH 0
+#define UREF_POOL_DEPTH 0
+
+static int events;
+
+/** definition of our uprobe */
+static int catch(struct uprobe *uprobe, struct upipe *upipe,
+                 int event, va_list args)
+{
+    switch (event) {
+        default:
+            assert(0);
+            break;
+        case UPROBE_READY:
+        case UPROBE_DEAD:
+            break;
+        case UPROBE_LOCAL:
+            events++;
+            break;
+    }
+    return UBASE_ERR_NONE;
+}
+
+/** definition of our uprobe */
+static int catch_dup(struct uprobe *uprobe, struct upipe *upipe,
+                     int event, va_list args)
+{
+    switch (event) {
+        default:
+            assert(0);
+            break;
+        case UPROBE_READY:
+        case UPROBE_DEAD:
+            break;
+        case UPROBE_LOCAL:
+            events++;
+            break;
+    }
+    return UBASE_ERR_NONE;
+}
+
+int main(int argc, char **argv)
+{
+    struct uprobe uprobe;
+    uprobe_init(&uprobe, catch, NULL);
+    struct uprobe *logger = uprobe_stdio_alloc(&uprobe, stdout,
+                                               UPROBE_LOG_VERBOSE);
+    assert(logger != NULL);
+
+    struct uprobe uprobe2;
+    uprobe_init(&uprobe2, catch_dup, NULL);
+
+    struct uprobe *uprobe_dup = uprobe_dup_alloc(uprobe_use(logger), &uprobe2,
+                                                 UPROBE_LOCAL);
+    assert(uprobe_dup != NULL);
+
+    struct upipe test_pipe;
+    test_pipe.uprobe = uprobe_dup;
+    struct upipe *upipe = &test_pipe;
+
+    ubase_assert(upipe_throw(upipe, UPROBE_READY));
+
+    ubase_assert(upipe_throw(upipe, UPROBE_LOCAL));
+
+    assert(events == 2);
+
+    uprobe_release(uprobe_dup);
+    uprobe_release(logger);
+    uprobe_clean(&uprobe);
+    uprobe_clean(&uprobe2);
+
+    return 0;
+}


### PR DESCRIPTION
Usage example:

+    FILE *f = fopen("log.txt", "w");
+    assert(f);
+    struct uprobe *uprobe_log = uprobe_stdio_alloc(NULL, f, loglevel);
+    uprobe_stdio_set_color(uprobe_log, true);
+    assert(uprobe_log != NULL);
+
     uprobe_main = uprobe_stdio_alloc(NULL, stderr, loglevel);
     assert(uprobe_main != NULL);
+    uprobe_main = uprobe_dup_alloc(uprobe_main, uprobe_log, UPROBE_LOG);
+    assert(uprobe_main != NULL);
+    uprobe_release(uprobe_log);

To get both terminal output and file output (with colors)