### PR TITLE
upipe_vblk: prevent useless ubuf manager requests 

### DIFF
--- a/lib/upipe-modules/upipe_video_blank.c
+++ b/lib/upipe-modules/upipe_video_blank.c
@@ -19,6 +19,7 @@
 #include "upipe/upipe_helper_output.h"
 #include "upipe/upipe_helper_flow_def.h"
 #include "upipe/upipe_helper_flow_format.h"
+#include "upipe/upipe_helper_flow_def_check.h"
 #include "upipe/upipe_helper_ubuf_mgr.h"
 
 #include "upipe/uref_pic_flow.h"
@@ -40,6 +41,8 @@ struct upipe_vblk {
     struct uref *flow_def;
     /** input flow definition */
     struct uref *input_flow_def;
+    /** provided flow format */
+    struct uref *flow_def_provided;
     /** flow attributes */
     struct uref *flow_attr;
     /** output state */
@@ -92,6 +95,7 @@ UPIPE_HELPER_FLOW_FORMAT(upipe_vblk, flow_format_request,
                          upipe_vblk_check_flow_format,
                          upipe_vblk_register_output_request,
                          upipe_vblk_unregister_output_request);
+UPIPE_HELPER_FLOW_DEF_CHECK(upipe_vblk, flow_def_provided)
 UPIPE_HELPER_UBUF_MGR(upipe_vblk, ubuf_mgr, flow_format, ubuf_mgr_request,
                       upipe_vblk_check,
                       upipe_vblk_register_output_request,
@@ -114,6 +118,7 @@ static void upipe_vblk_free(struct upipe *upipe)
     if (upipe_vblk->pic_attr)
         uref_free(upipe_vblk->pic_attr);
 
+    upipe_vblk_clean_flow_def_provided(upipe);
     upipe_vblk_clean_input(upipe);
     upipe_vblk_clean_ubuf_mgr(upipe);
     upipe_vblk_clean_flow_format(upipe);
@@ -149,6 +154,7 @@ static struct upipe *upipe_vblk_alloc(struct upipe_mgr *mgr,
     upipe_vblk_init_flow_format(upipe);
     upipe_vblk_init_ubuf_mgr(upipe);
     upipe_vblk_init_input(upipe);
+    upipe_vblk_init_flow_def_provided(upipe);
 
     struct upipe_vblk *upipe_vblk = upipe_vblk_from_upipe(upipe);
     upipe_vblk->ubuf = NULL;
@@ -374,7 +380,22 @@ static int upipe_vblk_check_flow_format(struct upipe *upipe,
     struct upipe_vblk *upipe_vblk = upipe_vblk_from_upipe(upipe);
     uref_attr_import(flow_format, upipe_vblk->flow_attr);
     uref_pic_flow_delete_surface_type(flow_format);
-    upipe_vblk_require_ubuf_mgr(upipe, flow_format);
+
+    if (upipe_vblk->ubuf_mgr &&
+        upipe_vblk_check_flow_def_provided(upipe, flow_format)) {
+        /* nothing changed */
+        uref_free(flow_format);
+        return UBASE_ERR_NONE;
+    }
+
+    upipe_vblk_store_flow_def_provided(upipe, flow_format);
+
+    /* something relevant changed? */
+    if (!upipe_vblk->ubuf_mgr ||
+        !ubase_check(ubuf_mgr_check(upipe_vblk->ubuf_mgr, flow_format)))
+        upipe_vblk_require_ubuf_mgr(upipe, uref_dup(flow_format));
+    else
+        return upipe_vblk_check(upipe, uref_dup(flow_format));
     return UBASE_ERR_NONE;
 }
 

--- a/tests/upipe_video_blank_test.c
+++ b/tests/upipe_video_blank_test.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 OpenHeadend S.A.R.L.
+ * Copyright (C) 2026 EasyTools
  *
  * Authors: Arnaud de Turckheim
  *
@@ -10,15 +11,18 @@
 
 #include "upipe/upipe_helper_upipe.h"
 #include "upipe/upipe_helper_urefcount.h"
-#include "upipe/upipe_helper_void.h"
+#include "upipe/upipe_helper_flow.h"
+#include "upipe/upipe_helper_flow_def_check.h"
 
 #include "upipe/uclock.h"
 #include "upipe/upipe.h"
 #include "upipe/uprobe.h"
 #include "upipe/uref.h"
+#include "upipe/uref_attr.h"
 #include "upipe/uref_std.h"
 #include "upipe/uref_void_flow.h"
 #include "upipe/uref_pic_flow.h"
+#include "upipe/uref_pic.h"
 #include "upipe/uref_dump.h"
 #include "upipe/umem.h"
 #include "upipe/umem_alloc.h"
@@ -44,16 +48,29 @@
 #define UBUF_SHARED_POOL_DEPTH 1
 #define UPROBE_LOG_LEVEL UPROBE_LOG_VERBOSE
 #define LIMIT 5
+#define HSIZE 10
+#define VSIZE 10
+
+UREF_ATTR_VOID(test, output, "test.out", output test attribute)
+UREF_ATTR_VOID(test, wanted, "test.want", wanted test attibutes)
+UREF_ATTR_UNSIGNED(test, count, "test.count", frame count)
 
 struct sink {
     struct upipe upipe;
     struct urefcount urefcount;
+    struct urequest *urequest;
+    struct uref *flow_def_wanted;
+    struct uref *flow_def_input;
     uint64_t count;
+    uint64_t hsize;
+    uint64_t vsize;
 };
 
 UPIPE_HELPER_UPIPE(sink, upipe, 0);
 UPIPE_HELPER_UREFCOUNT(sink, urefcount, sink_free);
-UPIPE_HELPER_VOID(sink);
+UPIPE_HELPER_FLOW(sink, UREF_PIC_FLOW_DEF);
+UPIPE_HELPER_FLOW_DEF_CHECK(sink, flow_def_wanted);
+UPIPE_HELPER_FLOW_DEF_CHECK(sink, flow_def_input);
 
 static void sink_free(struct upipe *upipe)
 {
@@ -63,22 +80,36 @@ static void sink_free(struct upipe *upipe)
 
     upipe_throw_dead(upipe);
 
+    assert(!sink->urequest);
+    sink_clean_flow_def_wanted(upipe);
+    sink_clean_flow_def_input(upipe);
     sink_clean_urefcount(upipe);
-    sink_free_void(upipe);
+    sink_free_flow(upipe);
 }
 
 static struct upipe *sink_alloc(struct upipe_mgr *mgr,
                                 struct uprobe *uprobe,
                                 uint32_t signature, va_list args)
 {
-    struct upipe *upipe = sink_alloc_void(mgr, uprobe, signature, args);
+    struct uref *flow_def = NULL;
+    struct upipe *upipe =
+        sink_alloc_flow(mgr, uprobe, signature, args, &flow_def);
     if (unlikely(!upipe))
         return NULL;
 
     sink_init_urefcount(upipe);
+    sink_init_flow_def_input(upipe);
+    sink_init_flow_def_wanted(upipe);
 
     struct sink *sink = sink_from_upipe(upipe);
     sink->count = 0;
+    sink->urequest = NULL;
+    sink->hsize = 0;
+    sink->vsize = 0;
+
+    sink_store_flow_def_wanted(upipe, flow_def);
+    uref_pic_flow_get_hsize(flow_def, &sink->hsize);
+    uref_pic_flow_get_vsize(flow_def, &sink->vsize);
 
     upipe_throw_ready(upipe);
 
@@ -89,32 +120,117 @@ static void sink_input(struct upipe *upipe, struct uref *uref,
                        struct upump **upump_p)
 {
     struct sink *sink = sink_from_upipe(upipe);
+    size_t hsize = 0;
+    size_t vsize = 0;
+    ubase_assert(uref_pic_size(uref, &hsize, &vsize, NULL));
+    if (sink->hsize)
+        assert(hsize == sink->hsize);
+    else if (sink->count < LIMIT - 1)
+        assert(hsize == HSIZE);
+    else
+        assert(hsize == HSIZE * 2);
+    if (sink->vsize)
+        assert(vsize == sink->vsize);
+    else if (sink->count < LIMIT - 1)
+        assert(vsize == VSIZE);
+    else
+        assert(vsize == VSIZE * 2);
 
     sink->count++;
+    upipe_info_va(upipe, "receive frame %" PRIu64, sink->count);
     assert(sink->count <= LIMIT);
     uref_dump(uref, upipe->uprobe);
     assert(uref->ubuf);
     uref_free(uref);
+
+    switch (sink->count) {
+        case 1: {
+            upipe_info_va(upipe, "negotiate same");
+            struct uref *flow_def = uref_dup(sink->flow_def_input);
+            assert(flow_def);
+            ubase_assert(
+                urequest_provide_flow_format(sink->urequest, flow_def));
+            break;
+        }
+        case 2: {
+            upipe_info_va(upipe, "negotiate new attr");
+            struct uref *flow_def = uref_dup(sink->flow_def_input);
+            assert(flow_def);
+            ubase_assert(uref_test_set_count(flow_def, sink->count));
+            ubase_assert(
+                urequest_provide_flow_format(sink->urequest, flow_def));
+            break;
+        }
+        case LIMIT - 1: {
+            upipe_info_va(upipe, "negotiate new size");
+            struct uref *flow_def = uref_dup(sink->flow_def_input);
+            assert(flow_def);
+            ubase_assert(uref_pic_flow_set_hsize(flow_def, HSIZE * 2));
+            ubase_assert(uref_pic_flow_set_vsize(flow_def, VSIZE * 2));
+            ubase_assert(
+                urequest_provide_flow_format(sink->urequest, flow_def));
+            break;
+        }
+    }
 }
 
 static int sink_set_flow_def(struct upipe *upipe, struct uref *flow_def)
 {
+    assert(!sink_check_flow_def_input(upipe, flow_def));
+
+    struct sink *sink = sink_from_upipe(upipe);
     uint64_t hsize = 0, vsize = 0;
     ubase_assert(uref_flow_match_def(flow_def, "pic."));
     ubase_assert(uref_pic_flow_get_hsize(flow_def, &hsize));
     ubase_assert(uref_pic_flow_get_vsize(flow_def, &vsize));
+    ubase_assert(uref_test_get_output(flow_def));
+    ubase_assert(uref_test_get_wanted(flow_def));
+    if (sink->count > 2)
+        ubase_assert(uref_test_get_count(flow_def, NULL));
+    if (sink->count < LIMIT - 1)
+        assert(hsize == HSIZE && vsize == VSIZE);
+    else
+        assert(hsize == HSIZE * 2 && vsize == VSIZE * 2);
+    flow_def = uref_dup(flow_def);
+    assert(flow_def);
+    sink_store_flow_def_input(upipe, flow_def);
     return UBASE_ERR_NONE;
 }
 
 static int sink_control(struct upipe *upipe, int command, va_list args)
 {
+    struct sink *sink = sink_from_upipe(upipe);
+
     switch (command) {
         case UPIPE_REGISTER_REQUEST: {
             struct urequest *urequest = va_arg(args, struct urequest *);
-            return upipe_throw_provide_request(upipe, urequest);
+            if (urequest->type != UREQUEST_FLOW_FORMAT)
+                return upipe_throw_provide_request(upipe, urequest);
+            assert(!sink->urequest);
+            sink->urequest = urequest_alloc_proxy(urequest);
+            assert(sink->urequest);
+
+            struct uref *flow_def = uref_dup(urequest->uref);
+            assert(flow_def);
+            if (unlikely(!ubase_check(uref_pic_flow_get_hsize(flow_def, NULL))))
+                uref_pic_flow_set_hsize(flow_def, HSIZE);
+            if (unlikely(!ubase_check(uref_pic_flow_get_vsize(flow_def, NULL))))
+                uref_pic_flow_set_vsize(flow_def, VSIZE);
+            uref_test_set_output(flow_def);
+            return urequest_provide_flow_format(sink->urequest, flow_def);
         }
-        case UPIPE_UNREGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST: {
+            struct urequest *urequest = va_arg(args, struct urequest *);
+            if (urequest->type != UREQUEST_FLOW_FORMAT)
+                return UBASE_ERR_NONE;
+            assert(sink->urequest);
+            struct urequest *upstream =
+                urequest_get_opaque(sink->urequest, struct urequest *);
+            assert(urequest == upstream);
+            urequest_free_proxy(sink->urequest);
+            sink->urequest = NULL;
             return UBASE_ERR_NONE;
+        }
 
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
@@ -170,37 +286,74 @@ int main(int argc, char *argv[])
     struct upipe_mgr *upipe_vblk_mgr = upipe_vblk_mgr_alloc();
     assert(upipe_vblk_mgr);
 
-    struct uref *flow_def = uref_pic_flow_alloc_def(uref_mgr, 1);
-    ubase_assert(uref_pic_flow_set_hsize(flow_def, 10));
-    ubase_assert(uref_pic_flow_set_vsize(flow_def, 10));
-    assert(flow_def);
+    {
+        uprobe_notice_va(logger, NULL, "starting test 1");
 
-    struct upipe *source = upipe_flow_alloc(upipe_vblk_mgr,
-                              uprobe_pfx_alloc(uprobe_use(logger),
-                                               UPROBE_LOG_LEVEL,
-                                               "vblk"),
-                              flow_def);
-    uref_free(flow_def);
-    assert(source);
+        struct uref *flow_def = uref_pic_flow_alloc_def(uref_mgr, 1);
+        ubase_assert(uref_pic_flow_set_hsize(flow_def, HSIZE));
+        ubase_assert(uref_pic_flow_set_vsize(flow_def, VSIZE));
+        ubase_assert(uref_test_set_wanted(flow_def));
+        assert(flow_def);
 
-    struct upipe *sink =
-        upipe_void_alloc_output(source, &sink_mgr,
-                                uprobe_pfx_alloc(uprobe_use(logger),
-                                                 UPROBE_LOG_LEVEL, "sink"));
-    assert(sink);
+        struct upipe *source = upipe_flow_alloc(
+            upipe_vblk_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "vblk"),
+            flow_def);
+        assert(source);
 
-    struct uref *input_flow_def = uref_void_flow_alloc_def(uref_mgr);
-    assert(input_flow_def);
-    ubase_assert(upipe_set_flow_def(source, input_flow_def));
-    uref_free(input_flow_def);
+        struct upipe *sink = upipe_flow_alloc_output(
+            source, &sink_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "sink"),
+            flow_def);
+        assert(sink);
+        uref_free(flow_def);
 
-    for (unsigned i = 0; i < LIMIT; i++) {
-        struct uref *uref = uref_alloc_control(uref_mgr);
-        upipe_input(source, uref, NULL);
+        struct uref *input_flow_def = uref_void_flow_alloc_def(uref_mgr);
+        assert(input_flow_def);
+        ubase_assert(upipe_set_flow_def(source, input_flow_def));
+        uref_free(input_flow_def);
+
+        for (unsigned i = 0; i < LIMIT; i++) {
+            struct uref *uref = uref_alloc_control(uref_mgr);
+            upipe_input(source, uref, NULL);
+        }
+        upipe_release(source);
+        upipe_release(sink);
     }
 
-    upipe_release(source);
-    upipe_release(sink);
+    {
+        uprobe_notice_va(logger, NULL, "starting test 2");
+
+        struct uref *flow_def = uref_pic_flow_alloc_def(uref_mgr, 1);
+        ubase_assert(uref_test_set_wanted(flow_def));
+        assert(flow_def);
+
+        struct upipe *source = upipe_flow_alloc(
+            upipe_vblk_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "vblk"),
+            flow_def);
+        assert(source);
+
+        struct upipe *sink = upipe_flow_alloc_output(
+            source, &sink_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "sink"),
+            flow_def);
+        assert(sink);
+        uref_free(flow_def);
+
+        struct uref *input_flow_def = uref_void_flow_alloc_def(uref_mgr);
+        assert(input_flow_def);
+        ubase_assert(upipe_set_flow_def(source, input_flow_def));
+        uref_free(input_flow_def);
+
+        for (unsigned i = 0; i < LIMIT; i++) {
+            struct uref *uref = uref_alloc_control(uref_mgr);
+            upipe_input(source, uref, NULL);
+        }
+        upipe_release(source);
+        upipe_release(sink);
+    }
+
     uprobe_release(logger);
     upipe_mgr_release(upipe_vblk_mgr);
     uclock_release(uclock);


### PR DESCRIPTION
Prevent the pipe from requesting a new ubuf manager if nothing relevant changed.