### PR TITLE
upipe_helper_bin_output: clear the output pointer when cleaning

### DIFF
--- a/include/upipe/upipe_helper_bin_output.h
+++ b/include/upipe/upipe_helper_bin_output.h
@@ -225,6 +225,7 @@ static void STRUCTURE##_clean_bin_output(struct upipe *upipe)               \
     }                                                                       \
     STRUCTURE##_clean_##LAST_INNER(upipe);                                  \
     upipe_release(s->OUTPUT);                                               \
+    s->OUTPUT = NULL;                                                       \
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
upipe_foo_clean_bin_output() released s->OUTPUT but left the pointer in place, so a bin whose external refcount dropped to zero kept answering UPIPE_GET_OUTPUT with a freed pipe.  The bin structure itself can easily outlive that: UPIPE_HELPER_UPROBE ties the inner probe to the bin's real refcount, so any inner still holding it pins the bin, and a queue source in the middle of dispatching pins itself via upump_common_dispatch().

upipe_foo_clean_output() in the sibling helper has always cleared both its output and its flow def; do the same here.