### PR TITLE
upipe_transfer: do not leak a reference when freeze fails

### DIFF
--- a/lib/upipe-modules/upipe_transfer.c
+++ b/lib/upipe-modules/upipe_transfer.c
@@ -632,8 +632,9 @@ static int _upipe_xfer_mgr_attach(struct upipe_mgr *mgr,
 static inline int _upipe_xfer_mgr_freeze(struct upipe_mgr *mgr)
 {
     struct upipe_xfer_mgr *xfer_mgr = upipe_xfer_mgr_from_upipe_mgr(mgr);
+    UBASE_RETURN(umutex_lock(xfer_mgr->mutex));
     upipe_mgr_use(mgr);
-    return umutex_lock(xfer_mgr->mutex);
+    return UBASE_ERR_NONE;
 }
 
 /** @This thaws the remote event loop previously frozen by @ref


### PR DESCRIPTION
Managers allocated without a mutex always hit this: umutex_lock(NULL) returns UBASE_ERR_INVALID, so upipe_work_freeze() bails out through UBASE_RETURN without setting upipe_work->frozen, and upipe_work_thaw() then returns early on !frozen without releasing. The refcount never reaches zero, UPIPE_XFER_DETACH is never sent, and the worker thread never leaves upump_mgr_run(), hanging shutdown.

Lock first and take the reference only once the lock is held. The failing path still returns UBASE_ERR_INVALID and leaves frozen untouched, so inner pipe access is unaffected.