### PR TITLE
upipe_blit: scale the bottom padding by the bottom padding

### DIFF
--- a/lib/upipe-modules/upipe_blit.c
+++ b/lib/upipe-modules/upipe_blit.c
@@ -414,7 +414,7 @@ static int upipe_blit_sub_provide_flow_format(struct upipe *upipe)
 
         if (src_vsize) {
             tpad = tpad * dest_vsize / src_vsize;
-            bpad = tpad * dest_vsize / src_vsize;
+            bpad = bpad * dest_vsize / src_vsize;
             vsize -= tpad + bpad;
             vsize -= vsize % vround;
             vposition += (dest_vsize - vsize - tpad - bpad) / 2 + tpad;


### PR DESCRIPTION
The vertical scaling of the destination rectangle derived bpad from tpad, so an asymmetric padding put the picture at the wrong size and position.  Only subpictures whose flow definition carries pic padding attributes are affected; for everything else both are zero.