### PR TITLE
upipe_h265f: declare one access unit of latency, consistently

### DIFF
--- a/lib/upipe-framers/upipe_h265_framer.c
+++ b/lib/upipe-framers/upipe_h265_framer.c
@@ -167,6 +167,9 @@ struct upipe_h265f {
     uint32_t chroma_idc;
     /** duration of a field */
     uint64_t duration;
+    /** duration of one access unit - the framer's own latency: it
+     * cannot output a picture before the next access unit begins */
+    uint64_t au_duration;
     /** true if frame_field is present */
     bool frame_field_present;
     /** number of extra slice header bits from PPS */
@@ -314,6 +317,7 @@ static struct upipe *upipe_h265f_alloc(struct upipe_mgr *mgr,
     upipe_h265f->cpb_size = 0;
     upipe_h265f->pic_struct = -1;
     upipe_h265f->duration = 0;
+    upipe_h265f->au_duration = 0;
     upipe_h265f->got_discontinuity = false;
     upipe_h265f->scan_context = UINT32_MAX;
     upipe_h265f->au_size = 0;
@@ -1218,9 +1222,24 @@ static bool upipe_h265f_activate_sps(struct upipe *upipe, uint32_t sps_id)
     }
 
     if (frame_rate.num) {
-        upipe_h265f->duration = UCLOCK_FREQ * frame_rate.den / frame_rate.num / 2;
+        /* duration stays in FIELD units for the pic_struct arithmetic in
+         * upipe_h265f_prepare_au. The VUI clock tick is one coded
+         * picture - a FIELD when field_seq_flag, a FRAME otherwise
+         * (unlike H.264 where the tick is always a field) - so only the
+         * progressive case halves; the unconditional halving this
+         * replaces made field-sequential durations half a field. */
+        upipe_h265f->duration = UCLOCK_FREQ * frame_rate.den / frame_rate.num;
+        if (!field_seq_flag)
+            upipe_h265f->duration /= 2;
+        /* the framer holds exactly one ACCESS UNIT - it cannot output a
+         * picture until the next AU begins - so its latency is one coded
+         * picture: a frame when progressive, a field when field_seq.
+         * Declared identically here and in the store_flow_def path,
+         * which used to declare only half of this. */
+        upipe_h265f->au_duration = field_seq_flag ?
+            upipe_h265f->duration : upipe_h265f->duration * 2;
         UBASE_FATAL(upipe, uref_clock_set_latency(flow_def,
-                    upipe_h265f->input_latency + upipe_h265f->duration * 2))
+                    upipe_h265f->input_latency + upipe_h265f->au_duration))
 
         uref_pic_set_progressive(flow_def, !field_seq_flag);
         if (field_seq_flag)
@@ -2056,9 +2075,9 @@ static void upipe_h265f_build_flow_def(struct upipe *upipe)
              upipe_h265f->encaps_input != upipe_h265f->encaps_output)
         upipe_h265f_build_global(upipe, flow_def);
 
-    if (upipe_h265f->duration) {
+    if (upipe_h265f->au_duration) {
         UBASE_FATAL(upipe, uref_clock_set_latency(flow_def,
-                         upipe_h265f->input_latency + upipe_h265f->duration))
+                         upipe_h265f->input_latency + upipe_h265f->au_duration))
     }
 
     upipe_h265f_store_flow_def(upipe, flow_def);


### PR DESCRIPTION
The framer's latency was declared differently at its two flow-def sites: the SPS-parse path declared duration*2 while the store_flow_def path declared duration - half a frame on progressive content, and that is the value a decoder downstream actually sees. Measured at the avcdec input on a 1080p59.94 stream: 0.5 frames.

The framer's real latency is one ACCESS UNIT - it cannot output a picture until the next AU begins - i.e. one coded picture: a frame when progressive, a field under field_seq_flag. Introduce au_duration holding exactly that and declare input_latency + au_duration at both sites.

Also fix the duration derivation it exposed: duration is kept in FIELD units for the pic_struct arithmetic in prepare_au, but the VUI clock tick is one coded picture - a field when field_seq_flag, a frame otherwise, unlike H.264 where it is always a field - so only the progressive case must halve. The previous unconditional halving made field-sequential durations half a field (and their pic_struct products wrong by 2x throughout).